### PR TITLE
Correctly escape XML characters found in property values

### DIFF
--- a/bundles/com.zeligsoft.domain.omg.ccm.descriptorgenerator/src/com/zeligsoft/domain/omg/ccm/descriptorgenerator/utils/CDPXtendUtils.java
+++ b/bundles/com.zeligsoft.domain.omg.ccm.descriptorgenerator/src/com/zeligsoft/domain/omg/ccm/descriptorgenerator/utils/CDPXtendUtils.java
@@ -253,9 +253,9 @@ public class CDPXtendUtils {
 	}
 
 	public static String xmlSanitize(String value) {
-		return (value == null) ? "" : value.replace("&", "&amp;")
-				.replace("<", "&lt;").replace(">", "zcxgt;")
-				.replace("'", "zcxapos;");
+		return (value == null) ? "" : value.replace("&", "zcxamp;")
+				.replace("<", "zcxlt;").replace(">", "zcxgt;")
+				.replace("'", "zcxapos;").replace("\"", "zcxquot;");
 	}
 
 	public static String replaceLast(String string, String replace,

--- a/bundles/com.zeligsoft.domain.omg.ccm.descriptorgenerator/src/com/zeligsoft/domain/omg/ccm/descriptorgenerator/utils/DescriptorBeautifier.java
+++ b/bundles/com.zeligsoft.domain.omg.ccm.descriptorgenerator/src/com/zeligsoft/domain/omg/ccm/descriptorgenerator/utils/DescriptorBeautifier.java
@@ -35,7 +35,9 @@ public class DescriptorBeautifier extends XMLBeautifier {
 		super.beforeWriteAndClose(impl);
 		// we want to place an extra new line between certain element tags
 		String buffer = impl.getBuffer().toString();
-		buffer = buffer.replace("zcxgt;", "&gt;").replace("zcxapos;", "&apos;").replace("&#xD;", "");
+		buffer = buffer.replace("zcxlt;", "&lt;").replace("zcxgt;", "&gt;")
+				.replace("zcxapos;", "&apos;").replace("&#xD;", "")
+				.replace("zcxamp;", "&amp;").replace("zcxquot;", "&quot;");
 		
 		for (String tag : separators){
 			String toReplace = "(</" + tag + ">)";


### PR DESCRIPTION
Fixing issue#9 by escaping some invalid xml characters which have not been properly escaped before.