### PR TITLE
Fix CX utilities/CodeGenUtil model validation bugs

### DIFF
--- a/bundles/com.zeligsoft.domain.dds4ccm.codegen/src/com/zeligsoft/domain/dds4ccm/codegen/utils/CodeGenUtil.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.codegen/src/com/zeligsoft/domain/dds4ccm/codegen/utils/CodeGenUtil.java
@@ -73,7 +73,7 @@ public class CodeGenUtil implements DDS4CCMGenerationListener {
 
 	public static CodeGenUtil INSTANCE = new CodeGenUtil();
 
-	private CodeGenUtil() {
+	private CodeGenUtil() { 
 		DDS4CCMGenerationUtils.addGenerationListener(this);
 	}
 

--- a/bundles/com.zeligsoft.domain.dds4ccm.codegen/src/com/zeligsoft/domain/dds4ccm/codegen/utils/CodeGenUtil.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.codegen/src/com/zeligsoft/domain/dds4ccm/codegen/utils/CodeGenUtil.java
@@ -43,6 +43,7 @@ import org.eclipse.emf.validation.service.IBatchValidator;
 import org.eclipse.uml2.uml.NamedElement;
 import org.osgi.framework.Bundle;
 
+import com.ibm.xtools.modeler.ui.UMLModeler;
 import com.zeligsoft.base.util.WorkflowUtil;
 import com.zeligsoft.cx.build.factory.ProjectFactory;
 import com.zeligsoft.cx.codegen.CodeGenWorkflowConstants;
@@ -162,15 +163,32 @@ public class CodeGenUtil implements DDS4CCMGenerationListener {
 	public IStatus validateModel(URI uri) {
 		DDS4CCMValidationFactory factory = new DDS4CCMValidationFactory();
 		IBatchValidator validator = factory.createValidator();
-		try {
-			Resource resource = rset.createResource(uri);
-			resource.load(Collections.EMPTY_MAP);
-			IStatus result = validator.validate(resource.getContents().get(0));
-			resource.unload();
-			return result;
-		} catch (IOException e) {
-			return createStatus(IStatus.ERROR, e.getMessage());
+		validator.setIncludeLiveConstraints(true);
+
+		Resource resource = UMLModeler.getEditingDomain().getResourceSet().getResource(uri, false);
+		
+		if(resource == null){
+			return createStatus(IStatus.ERROR, "Failed to create resource for URI: "+uri);
 		}
+		boolean isResourceLoadedAtEntry = resource.isLoaded();
+		
+		if(!isResourceLoadedAtEntry){
+			try{
+				resource.load(Collections.EMPTY_MAP);
+			}catch(IOException e) {
+				return createStatus(IStatus.ERROR, e.getMessage());
+			}	
+		}
+		
+		IStatus result = validator.validate(resource.getContents().get(0));
+	
+		// An unchecked exception java.util.ConcurrentModificationException can occur for once during validation 
+		// due to an issue with an IBM constraint: "com.ibm.xtools.uml.validation.components.assembly"; ignore
+				
+		if(!isResourceLoadedAtEntry && resource.isLoaded()){
+			resource.unload();
+		}
+		return result;
 	}
 
 	private IStatus doTransform(String pluginId, String workflowPath, URI uri) {


### PR DESCRIPTION
From the supplied URI object in the "validateModel" method, get the
existing model resource from the UMLModeler editingDomain, instead of
creating a new resource. This change is required for the selector object
of the IBM ClientContext "com.ibm.xtools.modeler.validation.client" to
recognize the corresponding eObject resource and include the standard
constraints from this ClientContext while validating the eObject.

Also, set the option for including live constraints to 'true'. This
ensures that the constraints with evaluation mode 'live' are included in
addition to 'batch' constraints while applying the batch validation.

Closes #23