### PR TITLE
Control Axcioma UI contribution through a plug-in fragment

### DIFF
--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/.classpath
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/.project
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.zeligsoft.domain.dds4ccm.ui.axcioma</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/META-INF/MANIFEST.MF
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %Bundle-Name
+Bundle-SymbolicName: com.zeligsoft.domain.dds4ccm.ui.axcioma;singleton:=true
+Bundle-Version: 1.6.0.qualifier
+Bundle-Vendor: %Bundle-Vendor
+Fragment-Host: com.zeligsoft.domain.dds4ccm.ui;bundle-version="3.5.1"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/OSGI-INF/l10n/bundle.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/OSGI-INF/l10n/bundle.properties
@@ -1,4 +1,5 @@
 #Properties file for com.zeligsoft.domain.dds4ccm.ui.axcioma
 Bundle-Vendor = ZELIGSOFT
-Bundle-Name = Axcioma Contribution
+Bundle-Name = AXCIOMA UI Enabler
 action.label.MigrateModelType = Migrate to AXCIOMA
+AXCIOMAPreferencePage.name = AXCIOMA

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/OSGI-INF/l10n/bundle.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/OSGI-INF/l10n/bundle.properties
@@ -1,0 +1,4 @@
+#Properties file for com.zeligsoft.domain.dds4ccm.ui.axcioma
+Bundle-Vendor = ZELIGSOFT
+Bundle-Name = Axcioma Contribution
+action.label.MigrateModelType = Migrate to AXCIOMA

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/build.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/build.properties
@@ -1,0 +1,6 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               fragment.xml,\
+               OSGI-INF/l10n/bundle.properties

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/fragment.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/fragment.xml
@@ -37,5 +37,14 @@
           </visibility>
        </viewerContribution>
    </extension>
+   <extension
+         point="org.eclipse.ui.preferencePages">
+       <page
+            category="cxModelingPreference"
+            class="com.zeligsoft.domain.dds4ccm.ui.preferences.DDS4CCMAxciomaMigrationPreferencePage"
+            id="com.zeligsoft.DDS4CCM.Axcioma"
+            name="%AXCIOMAPreferencePage.name">
+       </page>
+   </extension>      
 
 </fragment>

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/fragment.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/fragment.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.2"?>
+<fragment>
+   <extension
+         point="org.eclipse.ui.popupMenus">
+       <viewerContribution
+             id="com.zeligsoft.migrateModelType.popupmenu"
+             targetID="org.eclipse.ui.navigator.ProjectExplorer#PopupMenu">
+          <action
+                class="com.zeligsoft.domain.dds4ccm.ui.actions.MigrateModelTypeAction"
+                enablesFor="1"
+                id="com.zeligsoft.domain.dds4ccm.ui.actions.MigrateModelTypeAction"
+                label="%action.label.MigrateModelType"
+                menubarPath="org.eclipse.gmf.runtime.common.ui.actions.RefactorMenu/additions">
+          </action>
+          <visibility>
+             <and>
+                <or>
+                   <objectState
+                         name="isZDLConcept"
+                         value="DDS4CCM::DDS4CCM::DDS4CCMModel">
+                   </objectState>
+                   <objectState
+                         name="isZDLConcept"
+                         value="CCM::CCM_Component::CCMComponent">
+                   </objectState>
+                   <objectState
+                   		name="isZDLConcept"
+                   		value="CCM::CCM_Component::Home">
+                   	</objectState>
+                </or>
+                <objectState
+                      name="isZDLProfile"
+                      value="cxDDS4CCM">
+                </objectState>
+             </and>
+          </visibility>
+       </viewerContribution>
+   </extension>
+
+</fragment>

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/src/com/zeligsoft/domain/dds4ccm/ui/axcioma/AxciomaSupport.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.axcioma/src/com/zeligsoft/domain/dds4ccm/ui/axcioma/AxciomaSupport.java
@@ -1,0 +1,5 @@
+package com.zeligsoft.domain.dds4ccm.ui.axcioma;
+
+public class AxciomaSupport {
+
+}

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.properties
@@ -13,7 +13,7 @@ IDLImportWizard.name = IDL
 IDLImportWizard.description = Imports IDL resources into a model.
 category.name.0 = CCM
 wizard.name.0 = IDL Import
-
+ 
 action.label.show_source = Show Source
 action.addStructureDiagram = Composite Structure Diagram
 action.addStructureDiagram.tooltip = Create a new Composite Structure diagram

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.properties
@@ -29,8 +29,6 @@ registernaming.action.label.1 = Refactor RegisterNaming Properties
 clean.comments.action.label.1 = Clean Imported Comments
 reapply.field.stereotype.label.1 = Reapply Field Stereotypes
 
-action.label.MigrateModelType = Migrate to AXCIOMA
-
 #Diagram action labels
 diagram.action.label.component = CX Component Diagram
 diagram.action.tooltip.component = Create a new CX Component diagram

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
@@ -12,7 +12,7 @@
                enableNameSelection="true"
                showUsesList="true">
          </PortType>
-    </extension>
+    </extension> 
 	<extension
          point="org.eclipse.ui.newWizards">
       <category

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
@@ -690,12 +690,6 @@
             id="com.zeligsoft.DDS4CCM"
             name="%DDS4CCMPreferencePage.name">
       </page>
-      <page
-            category="cxModelingPreference"
-            class="com.zeligsoft.domain.dds4ccm.ui.preferences.DDS4CCMAxciomaMigrationPreferencePage"
-            id="com.zeligsoft.DDS4CCM.Axcioma"
-            name="AXCIOMA">
-      </page>
     </extension>
    <extension
          point="org.eclipse.ui.navigator.viewer">               

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
@@ -515,44 +515,6 @@
              </and>
           </visibility>
        </viewerContribution>
-       
-       
-       <viewerContribution
-             id="com.zeligsoft.migrateModelType.popupmenu"
-             targetID="org.eclipse.ui.navigator.ProjectExplorer#PopupMenu">
-          <action
-                class="com.zeligsoft.domain.dds4ccm.ui.actions.MigrateModelTypeAction"
-                enablesFor="1"
-                id="com.zeligsoft.domain.dds4ccm.ui.actions.MigrateModelTypeAction"
-                label="%action.label.MigrateModelType"
-                menubarPath="org.eclipse.gmf.runtime.common.ui.actions.RefactorMenu/additions">
-          </action>
-          <visibility>
-             <and>
-                <or>
-                   <objectState
-                         name="isZDLConcept"
-                         value="DDS4CCM::DDS4CCM::DDS4CCMModel">
-                   </objectState>
-                   <objectState
-                         name="isZDLConcept"
-                         value="CCM::CCM_Component::CCMComponent">
-                   </objectState>
-                   <objectState
-                   		name="isZDLConcept"
-                   		value="CCM::CCM_Component::Home">
-                   	</objectState>
-                </or>
-                <objectState
-                      name="isZDLProfile"
-                      value="cxDDS4CCM">
-                </objectState>
-             </and>
-          </visibility>
-       </viewerContribution>
-       
-       
-       
        <viewerContribution
              id="com.zeligsoft.refactorCleanComments.popupmenu"
              targetID="org.eclipse.ui.navigator.ProjectExplorer#PopupMenu">

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/utils/DDS4CCMUIUtil.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/utils/DDS4CCMUIUtil.java
@@ -1,0 +1,16 @@
+package com.zeligsoft.domain.dds4ccm.ui.utils;
+
+public class DDS4CCMUIUtil {
+	public static boolean isAxciomaSupported(){
+		boolean isAxciomaSupported = true;
+		try {
+			Class axciomaClass = Class.forName("com.zeligsoft.domain.dds4ccm.ui.axcioma.AxciomaSupport");
+			if(axciomaClass == null){
+				isAxciomaSupported = false;
+			}
+		} catch (ClassNotFoundException e) {
+			isAxciomaSupported = false;
+		}
+		return isAxciomaSupported;
+	}
+}

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/wizards/DDS4CCMModelWizardPage.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/wizards/DDS4CCMModelWizardPage.java
@@ -117,7 +117,7 @@ public class DDS4CCMModelWizardPage extends ZeligsoftModelWizardPage {
 				axciomaSelectionButton.setSelection(true);
 			}
 		}
-	}
+	} 
 	
 	public ModelTypeEnum getTargetModelType(){
 		

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/wizards/DDS4CCMModelWizardPage.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/wizards/DDS4CCMModelWizardPage.java
@@ -28,6 +28,7 @@ import org.eclipse.uml2.common.util.UML2Util;
 import com.zeligsoft.cx.ui.l10n.Messages;
 import com.zeligsoft.cx.ui.pages.ZeligsoftModelWizardPage;
 import com.zeligsoft.domain.dds4ccm.api.DDS4CCM.ModelTypeEnum;
+import com.zeligsoft.domain.dds4ccm.ui.utils.DDS4CCMUIUtil;
 
 import org.eclipse.swt.widgets.Button;
 
@@ -85,25 +86,11 @@ public class DDS4CCMModelWizardPage extends ZeligsoftModelWizardPage {
 		// TODO Auto-generated method stub
 		super.createControl(parent);
 		
-		if(isAxciomaSupported()){
+		if(DDS4CCMUIUtil.isAxciomaSupported()){
 			final Composite composite = (Composite) getControl();
 			// create a Group and two Radio buttons (Button) within it.
 			createModelTypeGroup(composite);
 		}
-	}
-	
-	public boolean isAxciomaSupported(){
-		boolean isAxciomaSupported = true;
-		try {
-			Class axciomaClass = Class.forName("com.zeligsoft.domain.dds4ccm.ui.axcioma.AxciomaSupport");
-			if(axciomaClass == null){
-				isAxciomaSupported = false;
-			}
-		} catch (ClassNotFoundException e) {
-			// TODO Auto-generated catch block
-			isAxciomaSupported = false;
-		}
-		return isAxciomaSupported;
 	}
 	
 	protected void createModelTypeGroup(Composite composite){
@@ -136,8 +123,7 @@ public class DDS4CCMModelWizardPage extends ZeligsoftModelWizardPage {
 	} 
 	
 	public ModelTypeEnum getTargetModelType(){
-		if(atcdSelectionButton == null){
-			// this will be entered for atcd-only version as the 'createModelTypeGroup' method will not be executed
+		if(!DDS4CCMUIUtil.isAxciomaSupported()){
 			return ModelTypeEnum.ATCD;
 		}
 		return atcdSelectionButton.getSelection()? ModelTypeEnum.ATCD : ModelTypeEnum.AXCIOMA;

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/wizards/DDS4CCMModelWizardPage.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/wizards/DDS4CCMModelWizardPage.java
@@ -84,10 +84,26 @@ public class DDS4CCMModelWizardPage extends ZeligsoftModelWizardPage {
 	public void createControl(Composite parent) {
 		// TODO Auto-generated method stub
 		super.createControl(parent);
-		final Composite composite = (Composite) getControl();
-		// create a Group and two Radio buttons (Button) within it.
-		createModelTypeGroup(composite);
 		
+		if(isAxciomaSupported()){
+			final Composite composite = (Composite) getControl();
+			// create a Group and two Radio buttons (Button) within it.
+			createModelTypeGroup(composite);
+		}
+	}
+	
+	public boolean isAxciomaSupported(){
+		boolean isAxciomaSupported = true;
+		try {
+			Class axciomaClass = Class.forName("com.zeligsoft.domain.dds4ccm.ui.axcioma.AxciomaSupport");
+			if(axciomaClass == null){
+				isAxciomaSupported = false;
+			}
+		} catch (ClassNotFoundException e) {
+			// TODO Auto-generated catch block
+			isAxciomaSupported = false;
+		}
+		return isAxciomaSupported;
 	}
 	
 	protected void createModelTypeGroup(Composite composite){
@@ -120,7 +136,10 @@ public class DDS4CCMModelWizardPage extends ZeligsoftModelWizardPage {
 	} 
 	
 	public ModelTypeEnum getTargetModelType(){
-		
+		if(atcdSelectionButton == null){
+			// this will be entered for atcd-only version as the 'createModelTypeGroup' method will not be executed
+			return ModelTypeEnum.ATCD;
+		}
 		return atcdSelectionButton.getSelection()? ModelTypeEnum.ATCD : ModelTypeEnum.AXCIOMA;
 	}
 }


### PR DESCRIPTION
The pop-up menu contribution for refactoring to Axcioma is extracted
from the "com.zeligsoft.domain.dds4ccm.ui" plug-in. It is now
contributed by a newly added fragment which the plug-in is hosting.

Also, for the creation of a new dds4ccm model, the radio button group
for choosing from 'Atcd' and 'Axcioma' in the model wizard is only been
created for a build that includes the above-mentioned fragment.

These changes are required for fixing issue #25: Creating two different installables from a single CX4CBDDS baseline.