### PR TITLE
Import ZMLMM package in the DDS4CCM model

### DIFF
--- a/bundles/com.zeligsoft.domain.dds4ccm/models/DDS4CCM.emx
+++ b/bundles/com.zeligsoft.domain.dds4ccm/models/DDS4CCM.emx
@@ -328,6 +328,9 @@
     <packageImport xmi:id="_txqUIHPtEd-Hgbsz-Pq3fg">
       <importedPackage xmi:type="uml:Model" href="pathmap://DDS_LIBRARIES/dds.uml#_NRAMoAwOEdmFcaeZXPdWAQ"/>
     </packageImport>
+    <packageImport xmi:id="_tYbWINu_EemLd89tONKGjQ">
+      <importedPackage xmi:type="uml:Model" href="pathmap://ZML_LIBRARIES/ZMLMM.uml#_NRAMoAwOEdmFcaeZXPdWAQ"/>
+    </packageImport>
     <packagedElement xmi:type="uml:Package" xmi:id="_eP42QEDSEd-VnJuJyqILLA" name="DDS4CCM" clientDependency="_TsGEkJICEeCsrOl-W1K_Dg">
       <eAnnotations xmi:id="_3UtgcEDkEd-LnsQ685SqSQ" source="uml2.diagrams">
         <contents xmi:type="umlnotation:UMLDiagram" xmi:id="_gpEZgEDlEd-LnsQ685SqSQ" type="Freeform" name="DDS4CCM">
@@ -1753,7 +1756,7 @@ endif&#xD;
         <ownedComment xmi:id="_ZlfbwI0eEemXDpqpOiiboQ">
           <body>%_desc_DDS4CCM__Constraints__deployment_parts_with_local_interface_collocation</body>
         </ownedComment>
-        <constrainedElement xmi:type="uml:Class" href="pathmap://ZML_LIBRARIES/ZMLMM.emx#_R1xfAEuREd2aAOSqOUjI9w?ZMLMM/ZML_Deployments/DeploymentPart?"/>
+        <constrainedElement xmi:type="uml:Class" href="pathmap://ZML_LIBRARIES/ZMLMM.uml#_UGsYwEuREd2aAOSqOUjI9w"/>
         <specification xmi:type="uml:OpaqueExpression" xmi:id="_ZlYuEI0eEemXDpqpOiiboQ">
           <language>Java</language>
           <body>com.zeligsoft.domain.dds4ccm.constraints.java.DeploymentPartsWithLocalInterfaceCollocationConstraint</body>

--- a/bundles/com.zeligsoft.domain.dds4ccm/models/DDS4CCM.uml
+++ b/bundles/com.zeligsoft.domain.dds4ccm/models/DDS4CCM.uml
@@ -13,6 +13,9 @@
     <packageImport xmi:id="_txqUIHPtEd-Hgbsz-Pq3fg">
       <importedPackage xmi:type="uml:Model" href="pathmap://DDS_LIBRARIES/dds.uml#_NRAMoAwOEdmFcaeZXPdWAQ"/>
     </packageImport>
+    <packageImport xmi:id="_tYbWINu_EemLd89tONKGjQ">
+      <importedPackage xmi:type="uml:Model" href="pathmap://ZML_LIBRARIES/ZMLMM.uml#_NRAMoAwOEdmFcaeZXPdWAQ"/>
+    </packageImport>
     <packagedElement xmi:type="uml:Package" xmi:id="_eP42QEDSEd-VnJuJyqILLA" name="DDS4CCM" clientDependency="_TsGEkJICEeCsrOl-W1K_Dg">
       <packagedElement xmi:type="uml:Class" xmi:id="_1fSP4EDkEd-LnsQ685SqSQ" name="DDS4CCMModel">
         <ownedRule xmi:id="_brzMkISmEeGcxphVxrnpvA" name="check_model_migration" constrainedElement="_1fSP4EDkEd-LnsQ685SqSQ">
@@ -368,7 +371,7 @@ endif&#xD;
         <ownedComment xmi:id="_ZlfbwI0eEemXDpqpOiiboQ">
           <body>%_desc_DDS4CCM__Constraints__deployment_parts_with_local_interface_collocation</body>
         </ownedComment>
-        <constrainedElement xmi:type="uml:Class" href="pathmap://ZML_LIBRARIES/ZMLMM.emx#_R1xfAEuREd2aAOSqOUjI9w"/>
+        <constrainedElement xmi:type="uml:Class" href="pathmap://ZML_LIBRARIES/ZMLMM.uml#_UGsYwEuREd2aAOSqOUjI9w"/>
         <specification xmi:type="uml:OpaqueExpression" xmi:id="_ZlYuEI0eEemXDpqpOiiboQ">
           <language>Java</language>
           <body>com.zeligsoft.domain.dds4ccm.constraints.java.DeploymentPartsWithLocalInterfaceCollocationConstraint</body>


### PR DESCRIPTION
The validation rule "deployment_parts_with_local_interface_collocation"
in DDS4CCM refers to the "ComponentDeploymentPart" in the ZMLMM package.
Therefore, it is necessary to import the ZMLMM package in DDS4CCM for
the proper loading of this validation constraint.