### PR TITLE
Fix erroneous connection generation for unconnected ports in an assembly instance

### DIFF
--- a/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAxcioma.ext
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAxcioma.ext
@@ -761,15 +761,15 @@ Void visitPartForExternalConnectons(DeploymentPart partDP, CCM::CCM_Deployment::
 	portsForGeneration.select(port| visitPortForExternalConnectons(partDP, port, zDeployment, plan));
 
 Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) : 
-	let terminalConnectedEnds = getTerminalConnectedCE(port, partDP, deployment):
-	terminalConnectedEnds.select(tce| visitPortForExternalConnectons(partDP, port, tce.partWithPort, tce.port, deployment, plan));
+	let terminalConnectedPortDP = getTerminalConnectedPortDP(port, partDP, deployment):
+	terminalConnectedPortDP.select(tce| visitPortForExternalConnectons(partDP, port, tce.getParentPart(), tce.modelElement, deployment, plan));
 
 cached Allocation getDeploymentTarget(CCM::CCM_Deployment::DeploymentPlan deployment, CCMPart part):
 	deployment.allocation.select( e | e.deployed.modelElement.contains( part ));
 
 // Assumption: 'port' for which the method is called for from another method is a terminal port as well 
-cached List[ConnectorEnd] getTerminalConnectedCE(InterfacePort port, DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment):
-	let terminalConnectedCE = {}:
+cached List[DeploymentPart] getTerminalConnectedPortDP(InterfacePort port, DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment):
+	let terminalConnectedPortDP = {}:
 	let part = partDP.modelElement:
 	
 	if (part.isPortConnectedInOwnerAssemblyOfPart(port)) then{
@@ -783,13 +783,13 @@ cached List[ConnectorEnd] getTerminalConnectedCE(InterfacePort port, DeploymentP
 		let connectedCEDelegation = portConnectorsDelegation.end.reject(e| e.port == port) :
 		
 		if (connectedCEAssembly.size > 0) then{	
-			connectedCEAssembly.select(ca_ce | terminalConnectedCE.addAll(getTerminalConnectedCEHelper(partDP, ca_ce).reject( ce | ce.getPossibleConnectedPorts(port).select( p2 | p2 == ce.port).size == 0)))	//			getTerminalConnectedCEHelper(connectedCEAssembly).reject( ce | possibleConnectedPorts.select( p2 | p2 == ce.port).size == 0))
+			connectedCEAssembly.select(ca_ce | terminalConnectedPortDP.addAll(getTerminalConnectedPortHelperDP(partDP.getParentPart(), ca_ce)))
 		} ->
 		if (connectedCEDelegation.size > 0) then{
-			connectedCEDelegation.select(ce| terminalConnectedCE.addAll(ce.port.getTerminalConnectedCE(partDP.getParentPart(), zDeployment))) 
+			connectedCEDelegation.select(ce| terminalConnectedPortDP.addAll(ce.port.getTerminalConnectedPortDP(partDP.getParentPart(), zDeployment))) 
 		}
 	} ->
-	terminalConnectedCE;
+	terminalConnectedPortDP;
 
 cached Boolean isPortConnectedInOwnerAssemblyOfPart(CCMPart part, InterfacePort port):
 	part.zdlAsProperty().owner.connector.end.port.contains(port);
@@ -797,28 +797,30 @@ cached Boolean isPortConnectedInOwnerAssemblyOfPart(CCMPart part, InterfacePort 
 cached getPossibleConnectedPorts(ConnectorEnd connectedCE, InterfacePort port):
 	connectedCE.partWithPort.zdlAsProperty().owner.part.definition.typeSelect(CCMComponent).ownedPort.select( zport | zport.isConjugated != port.isConjugated).select(zport | zport.porttype == port.porttype);
 			
-cached List[ConnectorEnd] getTerminalConnectedCEHelper(DeploymentPart containerPartDP, ConnectorEnd connectedCEAssembly):
-	let terminalConnectedCE = {}:
+cached List[DeploymentPart] getTerminalConnectedPortHelperDP(DeploymentPart containerPartDP, ConnectorEnd connectedCEAssembly):
+	let terminalConnectedPortDP = {}:
 	let assembly_impl = getAssembly(connectedCEAssembly.partWithPort.definition) :
+	let partDP = containerPartDP.nestedPart.select( np | np.modelElement == connectedCEAssembly.partWithPort).first():
 	
 	{if(assembly_impl.size == 0) then{
 		// Filter out the external ports by taking the intersection of the possible connected ports and the connected assembly ports.
-		terminalConnectedCE.add(connectedCEAssembly)
+		let portDP = partDP.nestedPart.select( np | np.modelElement == connectedCEAssembly.port).first():
+		
+		terminalConnectedPortDP.add(portDP)
 	}else{	// delegation exists in the connected part
-		let partDP = containerPartDP.nestedPart.select( np | np.modelElement == connectedCEAssembly.partWithPort).first():
-		let connectedCEInDelegation = assembly_impl.connector.end.reject( e | e.port == connectedCEAssembly.port):
-		connectedCEInDelegation.select(ce_de| terminalConnectedCE.addAll(getTerminalConnectedCEHelper(partDP, ce_de)))
+		
+		let connectedCEInDelegation = assembly_impl.connector.select(c| c.end.port.contains(connectedCEAssembly.port)).end.reject( e | e.port == connectedCEAssembly.port):		
+		connectedCEInDelegation.select(ce_de| terminalConnectedPortDP.addAll(getTerminalConnectedPortHelperDP(partDP, ce_de)))
 	}} ->
-	terminalConnectedCE;
+	terminalConnectedPortDP;
 
-Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, CCMPart connectedPart, InterfacePort connectedPort, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :	
+Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, DeploymentPart connectedPartDP, InterfacePort connectedPort, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :	
 	
-	let connectedPartDP = deployment.part.select( p | p.modelElement == connectedPart):
 	// Maintain same signature for avoiding duplicated connetions
 	if(port.isConjugated) then{
-		connectedPartDP.select(cpdp| createClientServerConnection(partDP, port, cpdp, connectedPort, plan))
+		createClientServerConnection(partDP, port, connectedPartDP, connectedPort, plan)
 	}else{
-		connectedPartDP.select(cpdp| createClientServerConnection(cpdp, connectedPort, partDP, port, plan))
+		createClientServerConnection(connectedPartDP, connectedPort, partDP, port, plan)
 	};
 	
 // return connetorInstance corresponding to the 'port' owned by the 'part' 	
@@ -913,12 +915,9 @@ create InstanceDeploymentDescription createInternalConnectorFragments(Deployment
 	
 	
 cached Boolean existsUndeployedConnectedPart(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment):
-	let terminalConnectedEnds = getTerminalConnectedCE(port, partDP, deployment):
-	let connectedParts = terminalConnectedEnds.partWithPort:
-	let connectedPartsDP = deployment.part.select( p | connectedParts.contains(p.modelElement)):
-	connectedPartsDP.exists(cpDP| !cpDP.isDeployed());
+	let terminalConnectedPortDP = getTerminalConnectedPortDP(port, partDP, deployment):	
+	terminalConnectedPortDP.exists(cpDP| !cpDP.getParentPart().isDeployed());
 	
-
 cached String getConnectorFragmentScopedName(DeploymentPart partDP, InterfacePort port):
 	partDP.getScopedName() + "." + port.name;
 	


### PR DESCRIPTION
For retrieving the connected parts from a given port, deployed port property is used for retrieving the parent ComponentDeploymentPart. This ensures that we have the correct ComponentDeploymentPart from the deployment editor for deciding which port instances we need to make connections with. 

This fixes issue#6.