### PR TITLE
Update build configuration for CX4CBDDS project for Papyrus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: java
 
-# Need to tell the Maven build the root directory of the build...
-env:
-- DDS4CCM_ROOT=$TRAVIS_BUILD_DIR
-
 # Default script is 'mvn test'; We don't have any tests, as we require RSA. Echo something useful, instead
 before_install:
   - sudo apt-get update

--- a/bundles/com.zeligsoft.base.zdl/src/com/zeligsoft/base/zdl/listeners/ZDLElementTypeResourceSetListener.java
+++ b/bundles/com.zeligsoft.base.zdl/src/com/zeligsoft/base/zdl/listeners/ZDLElementTypeResourceSetListener.java
@@ -54,7 +54,7 @@ import org.eclipse.uml2.uml.UMLPackage;
 import com.zeligsoft.base.zdl.type.ZDLElementType;
 import com.zeligsoft.base.zdl.type.ZDLElementTypeManager;
 import com.zeligsoft.base.zdl.util.ZDLUtil;
-import com.zeligsoft.base.zdl.xtend.MainTransform;
+//import com.zeligsoft.base.zdl.xtend.MainTransform;
 
 /**
  * ResourceSetListener which creates ZDLElementTypes when ZDL generated profiles

--- a/bundles/com.zeligsoft.domain.cbdds.architecture/build.properties
+++ b/bundles/com.zeligsoft.domain.cbdds.architecture/build.properties
@@ -1,4 +1,7 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               elementtypes/,\
+               models/,\
+               plugin.xml

--- a/bundles/com.zeligsoft.domain.dds4ccm.idlimport/src/com/zeligsoft/domain/dds4ccm/idlimport/ImportOrganizer.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.idlimport/src/com/zeligsoft/domain/dds4ccm/idlimport/ImportOrganizer.java
@@ -35,7 +35,7 @@ import org.eclipse.uml2.uml.Package;
 import org.eclipse.uml2.uml.PackageableElement;
 import org.eclipse.uml2.uml.Property;
 
-import com.ibm.xtools.uml.type.UMLElementFactory;
+//import com.ibm.xtools.uml.type.UMLElementFactory;
 import com.zeligsoft.base.zdl.util.ZDLUtil;
 import com.zeligsoft.domain.dds4ccm.DDS4CCMNames;
 import com.zeligsoft.domain.idl3plus.IDL3PlusNames;

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -13,10 +13,6 @@
 
     <modules>
         <module>com.zeligsoft.base</module>
-        <module>com.zeligsoft.base.diagram</module>
-        <module>com.zeligsoft.base.licensing</module>
-        <module>com.zeligsoft.base.licensing.ui</module>
-        <module>com.zeligsoft.base.testsupport</module>
         <module>com.zeligsoft.base.toolingmodel</module>
         <module>com.zeligsoft.base.ui</module>
         <module>com.zeligsoft.base.ui.menus</module>
@@ -32,10 +28,9 @@
         <module>com.zeligsoft.cx.codegen.ui</module>
         <module>com.zeligsoft.cx.deployment.treeeditor</module>
         <module>com.zeligsoft.cx.deployment.ui</module>
-        <module>com.zeligsoft.cx.langc</module>
-        <module>com.zeligsoft.cx.problem.navigation</module>
         <module>com.zeligsoft.cx.ui</module>
         <module>com.zeligsoft.cx.ui.properties</module>
+        <module>com.zeligsoft.domain.cbdds.architecture</module>
         <module>com.zeligsoft.domain.dds4ccm</module>
         <module>com.zeligsoft.domain.dds4ccm.amiconnector</module>
         <module>com.zeligsoft.domain.dds4ccm.api</module>
@@ -60,7 +55,6 @@
         <module>com.zeligsoft.domain.omg.ccm.descriptorgenerator</module>
         <module>com.zeligsoft.domain.omg.ccm.generator</module>
         <module>com.zeligsoft.domain.omg.ccm.idlimport</module>
-        <module>com.zeligsoft.domain.omg.ccm.rsm</module>
         <module>com.zeligsoft.domain.omg.ccm.ui</module>
         <module>com.zeligsoft.domain.omg.corba</module>
         <module>com.zeligsoft.domain.omg.corba.api</module>

--- a/features/com.zeligsoft.base-feature/feature.xml
+++ b/features/com.zeligsoft.base-feature/feature.xml
@@ -35,13 +35,6 @@
    </license>
 
    <plugin
-         id="com.zeligsoft.base.diagram"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="com.zeligsoft.base.ui"
          download-size="0"
          install-size="0"
@@ -89,7 +82,7 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-         
+		 
    <plugin
          id="com.zeligsoft.base.zdl.domain.staticapi"
          download-size="0"
@@ -105,28 +98,7 @@
          unpack="false"/>
 
    <plugin
-         id="com.zeligsoft.base.licensing"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.zeligsoft.base.licensing.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="com.zeligsoft.base.ui.menus"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.zeligsoft.base.testsupport"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/com.zeligsoft.cx-feature/feature.xml
+++ b/features/com.zeligsoft.cx-feature/feature.xml
@@ -84,20 +84,6 @@
          unpack="false"/>
 
    <plugin
-         id="com.zeligsoft.cx.problem.navigation"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.zeligsoft.cx.langc"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="com.zeligsoft.cx.codegen.ui"
          download-size="0"
          install-size="0"

--- a/features/com.zeligsoft.domain.ngc.ccm-feature/feature.xml
+++ b/features/com.zeligsoft.domain.ngc.ccm-feature/feature.xml
@@ -120,4 +120,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="com.zeligsoft.domain.cbdds.architecture"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/features/com.zeligsoft.domain.ngc.ccm.axcioma-feature/feature.xml
+++ b/features/com.zeligsoft.domain.ngc.ccm.axcioma-feature/feature.xml
@@ -127,4 +127,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="com.zeligsoft.domain.cbdds.architecture"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/features/com.zeligsoft.domain.omg.ccm-feature/feature.xml
+++ b/features/com.zeligsoft.domain.omg.ccm-feature/feature.xml
@@ -39,13 +39,6 @@
          unpack="false"/>
 
    <plugin
-         id="com.zeligsoft.domain.omg.ccm.rsm"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="com.zeligsoft.domain.omg.ccm.ui"
          download-size="0"
          install-size="0"

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,10 @@
 # Building DDS4CCM
 
-DDS4CCM is a Rational Software Architect (RSA) add-in for modeling component based systems
+DDS4CCM is a Papyrus add-in for modeling component based systems
 according to the OMG CCM standard.
 
 DDS4CCM has support for the following CCM implementations:
-- [CIAO](https://www.dre.vanderbilt.edu/~schmidt/CIAO.html)
-- [AXCIOMA](https://www.axcioma.com)
+- [AXCIOMA](https://www.axcioma.org)
 
 ## Build requirements
 
@@ -18,17 +17,15 @@ The build requires:
 
 1. Clone the DDS4CCM git repository.
 2. Start a shell, and change directory to the repository root.
-3. To run the build, execute the following commands
+3. Checkout the `papyrus` branch.
+4. To run the build, execute the following commands
 
 <pre>
 	# increase Maven memory
 	export MAVEN_OPTS="-Xmx1024m"
 	# build
-	mvn -D "dds4ccm.root=`pwd`" clean verify
+	mvn clean verify
 </pre>
-
-In Windows environments, you can use the fully qualified path name of the current
-directory rather than using the result of the embedded `pwd` command.
 
 On macOS, it was is necessary to increase the shell's maximum number of open files.
 The following was found to be acceptable:
@@ -49,10 +46,11 @@ to distinguish build between results of successive builds.
 
 ## Installing
 
-DDS4CCM can be installed in Rational Software Architect (RSA), versions 9.5, 9.6 or 9.7.
-A default RSA installation should be sufficient. To install:
+DDS4CCM can be installed in Eclipse Papyrus 2019-06 release (4.4.0). 
+The release can be downloaded from `https://www.eclipse.org/papyrus/download.html`.
+A default installation should be sufficient. To install:
 
-1. Start RSA as a super user. **This is important.**
+1. Start Papyrus as a super user. **This is important.**
 2. From the **Help** menu, choose **Install New Software** to start the **Install** wizard.
 3. On the **Available Software** page, click the **Add** button, to add a new software site.
 4. In the **Add Repository** dialog, click the **Archive** button, and in the dialog, browse for
@@ -62,26 +60,31 @@ the `com.zeligsoft.dds4ccm.update.atcd-*.zip` or `com.zeligsoft.dd44ccm.update.a
 Optionally, you may check **CDT** to install the C/C++ development tools.
 The **CX CBDDS Runtime Dependencies** features are always installed if you select
 **CX CBDDS**. They are listed primarily for developers.
-7. With the your installation features selected, press **Next**.
+7. With the installation features selected, press **Next**.
 8. On the **Install Details** page, you should see additional information on features to
 be installed.
 If error messages are reported, please contact us. Click **Next** to continue.
 9. On the **Review Licenses** page, click the **I accept...** radio button, then click **Finish**.
 10. During the execution of the wizard, your may be prompted to approve the installation
 of unsigned features. This will all have `com.zeligsoft` as a prefix to their names. Approve them.
-With RSA 9.6 and RSA 9.7, you may be prompted to approve the signing certificate for Eclipse.org.
-Approve it.
-11. Once the install has completed, you will be prompted to restart RSA. Do this.
-12. Once restarted, you may exit RSA (which you started as a super user in step 1).
+11. Once the install has completed, you will be prompted to restart Papyrus. Do this.
+12. Once restarted, you may exit Papyrus (which you started as a super user in step 1).
 
 ## Using CX CBDDS (aka DDS4CCM)
 
 To use CX CBDDS:
-1. start RSA as a regular user.
+1. start Papyrus as a regular user.
 2. Choose a 'workspace' location, if prompted. This will be the disk location where your
 DDS4CCM projects will be stored.
-3. Ensure the DDS4CCM 'perspective' is open: Choose **Window** > **Open Perspective** >
-**Other**, and choose **DDS4CCM**. Click **OK**.
-4. The **File** menu will then have an option **New DDS4CCM Project**.
+3. From the **File** menu, click on **New > Papyrus Project**. 
+This will open up the **New Papyrus Project** wizard.
+4. In the **Architecture Contexts** section of the **New Papyrus Project** page, 
+there should be options for selecting **ATCD** or **AXCIOMA** under **Software Engineering** context.
+Selecting one of these options will show up respective viewpoints in the **Architecture Viewpoints** section.
+5. Select an architecture context and click **Next**.
+6. Enter a project name and click **Next** to continue.
+7. In the **Initialization Information** page, enter a root model element name and click **Finish**.
+8. This should create a Papyrus model with appropriate profile and stereotype application. 
+Clicking on the model in the **Model Explorer** view shows the relevant information in the **Properties** tab.     
 
 Further tutorial information is not currently stored in this project.

--- a/releng/com.zeligsoft.dds4ccm.configuration/pom.xml
+++ b/releng/com.zeligsoft.dds4ccm.configuration/pom.xml
@@ -8,26 +8,25 @@
  <properties>
   <tycho.version>1.3.0</tycho.version>
   <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
-  <dds4ccm.root>${env.DDS4CCM_ROOT}</dds4ccm.root>
-  <cx95-repo.url>file://${dds4ccm.root}/deps/cx95_target_p2/</cx95-repo.url>
-  <luna-repo.url>http://download.eclipse.org/releases/luna/</luna-repo.url>
-  <cdt-86-repo.url>http://download.eclipse.org/tools/cdt/releases/8.6</cdt-86-repo.url>
+  <eclipse-release.url>http://download.eclipse.org/releases/2019-06/</eclipse-release.url>
+  <papyrus.url>http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/2019-06/</papyrus.url>
+  <cdt-98-repo.url>http://download.eclipse.org/tools/cdt/releases/9.8/</cdt-98-repo.url>
  </properties>
 
  <repositories>
   <repository>
-   <id>cx95-repo</id>
-   <url>${cx95-repo.url}</url>
+   <id>eclipse-release</id>
+   <url>${eclipse-release.url}</url>
    <layout>p2</layout>
   </repository>
   <repository>
-   <id>luna-repo</id>
-   <url>${luna-repo.url}</url>
+   <id>papyrus</id>
+   <url>${papyrus.url}</url>
    <layout>p2</layout>
   </repository>
   <repository>
-   <id>cdt-86-repo</id>
-   <url>${cdt-86-repo.url}</url>
+   <id>cdt-98-repo</id>
+   <url>${cdt-98-repo.url}</url>
    <layout>p2</layout>
   </repository>
 

--- a/releng/com.zeligsoft.dds4ccm.update.atcd/category.xml
+++ b/releng/com.zeligsoft.dds4ccm.update.atcd/category.xml
@@ -12,86 +12,75 @@
    <feature url="features/com.zeligsoft.cx_3.6.6.qualifier.jar" id="com.zeligsoft.cx" version="3.6.6.qualifier">
       <category name="com.zeligsoft.dds4ccmmaster.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.sdk_8.6.0.201502131403.jar" id="org.eclipse.cdt.sdk" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt_9.8.1.201907021957.jar" id="org.eclipse.cdt" version="9.8.1.201907021957">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.gdb_8.6.0.201502131403.jar" id="org.eclipse.cdt.gdb" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.gdb_9.8.1.201906192008.jar" id="org.eclipse.cdt.gdb" version="9.8.1.201906192008">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.platform_8.6.0.201502131403.jar" id="org.eclipse.cdt.platform" version="8.6.0.201502131403">
-      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   <feature url="features/org.eclipse.cdt.gnu.build_9.8.1.201906192008.jar" id="org.eclipse.cdt.gnu.build" version="9.8.1.201906192008">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.native_8.6.0.201502131403.jar" id="org.eclipse.cdt.native" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.gnu.debug_9.8.1.201906192008.jar" id="org.eclipse.cdt.gnu.debug" version="9.8.1.201906192008">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt_8.6.0.201502131403.jar" id="org.eclipse.cdt" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.native_9.8.1.201906192008.jar" id="org.eclipse.cdt.native" version="9.8.1.201906192008">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.gnu.dsf_8.6.0.201502131403.jar" id="org.eclipse.cdt.gnu.dsf" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.platform_9.8.1.201907021957.jar" id="org.eclipse.cdt.platform" version="9.8.1.201907021957">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.gnu.build_8.6.0.201502131403.jar" id="org.eclipse.cdt.gnu.build" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.sdk_9.8.1.201907021957.jar" id="org.eclipse.cdt.sdk" version="9.8.1.201907021957">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.gnu.debug_8.6.0.201502131403.jar" id="org.eclipse.cdt.gnu.debug" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.gnu.dsf_9.8.1.201906211704.jar" id="org.eclipse.cdt.gnu.dsf" version="9.8.1.201906211704">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.emf.mwe.core_1.3.4.v201409021027.jar" id="org.eclipse.emf.mwe.core" version="1.3.4.v201409021027">
-      <category name="com.zelgisoft.dds4ccm.deps.category"/>
-   </feature>
-   <feature url="features/org.eclipse.xtext.runtime_2.7.3.v201411190455.jar" id="org.eclipse.xtext.runtime" version="2.7.3.v201411190455">
+   <feature url="features/org.eclipse.xtext.runtime_2.18.0.v20190528-0716.jar" id="org.eclipse.xtext.runtime" version="2.18.0.v20190528-0716">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtext.ui_2.7.3.v201411190455.jar" id="org.eclipse.xtext.ui" version="2.7.3.v201411190455">
+   <feature url="features/org.eclipse.xtext.ui_2.18.0.v20190528-0716.jar" id="org.eclipse.xtext.ui" version="2.18.0.v20190528-0716">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtext.xbase.lib_2.7.3.v201411190455.jar" id="org.eclipse.xtext.xbase.lib" version="2.7.3.v201411190455">
+   <feature url="features/org.eclipse.xtext.xbase.lib_2.18.0.v20190528-0419.jar" id="org.eclipse.xtext.xbase.lib" version="2.18.0.v20190528-0419">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtend_2.0.0.v201406030414.jar" id="org.eclipse.xtend" version="2.0.0.v201406030414">
+   <feature url="features/org.eclipse.xtend_2.2.0.v201605260315.jar" id="org.eclipse.xtend" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtend.typesystem.uml2_2.0.0.v201406030414.jar" id="org.eclipse.xtend.typesystem.uml2" version="2.0.0.v201406030414">
+   <feature url="features/org.eclipse.xtend.typesystem.uml2_2.2.0.v201605260315.jar" id="org.eclipse.xtend.typesystem.uml2" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtend.typesystem.xsd_2.0.0.v201406030414.jar" id="org.eclipse.xtend.typesystem.xsd" version="2.0.0.v201406030414">
+   <feature url="features/org.eclipse.xtend.typesystem.xsd_2.2.0.v201605260315.jar" id="org.eclipse.xtend.typesystem.xsd" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
    <feature url="features/com.zeligsoft.domain.ngc.ccm_feature_1.6.0.qualifier.jar" id="com.zeligsoft.domain.ngc.ccm_feature" version="1.6.0.qualifier">
       <category name="com.zeligsoft.dds4ccmmaster.category"/>
    </feature>
-   <bundle id="com.google.guava" version="15.0.0.v201403281430">
+   <bundle id="org.eclipse.emf.mwe.ui" version="1.4.0">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="com.google.inject" version="3.0.0.v201312141243">
+   <bundle id="com.google.guava" version="21.0.0.v20170206-1425">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.xpand" version="2.0.0.v201406030414">
+   <bundle id="com.google.inject" version="3.0.0.v201605172100">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.xtend.shared.ui" version="2.0.0.v201406030414">
+   <bundle id="org.eclipse.xpand" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.xtend2.lib" version="2.7.3.v201411190455">
+   <bundle id="org.eclipse.xtend.shared.ui" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.emf.mwe2.runtime" version="2.7.0.v201409021027">
+   <bundle id="org.eclipse.xtend.ide" version="2.18.0.v20190528-0610">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.emf.mwe.ui" version="1.3.4.v201409021027">
-      <category name="com.zelgisoft.dds4ccm.deps.category"/>
-   </bundle>
-   <bundle id="org.eclipse.xtend.lib" version="2.7.3.v201411190455">
-      <category name="com.zelgisoft.dds4ccm.deps.category"/>
-   </bundle>
-   <bundle id="org.eclipse.xtend.lib.macro" version="2.7.3.v201411190455">
+   <bundle id="org.eclipse.xtend.typesystem.emf" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
    <category-def name="com.zelgisoft.dds4ccm.cdt.category" label="CDT">
       <description>
-         Supplemental C/C++ Development tools, version 8.6. Based on Eclipse Luna (4.4),
-   and compatibile with RSA 9.5 or later.
+         Supplemental C/C++ Development tools, version 9.8.1.
       </description>
    </category-def>
    <category-def name="com.zeligsoft.dds4ccmmaster.category" label="CX CBDDS">

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/category.xml
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/category.xml
@@ -12,86 +12,75 @@
    <feature url="features/com.zeligsoft.cx_3.6.6.qualifier.jar" id="com.zeligsoft.cx" version="3.6.6.qualifier">
       <category name="com.zeligsoft.dds4ccmmaster.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.sdk_8.6.0.201502131403.jar" id="org.eclipse.cdt.sdk" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt_9.8.1.201907021957.jar" id="org.eclipse.cdt" version="9.8.1.201907021957">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.gdb_8.6.0.201502131403.jar" id="org.eclipse.cdt.gdb" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.gdb_9.8.1.201906192008.jar" id="org.eclipse.cdt.gdb" version="9.8.1.201906192008">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.platform_8.6.0.201502131403.jar" id="org.eclipse.cdt.platform" version="8.6.0.201502131403">
-      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   <feature url="features/org.eclipse.cdt.gnu.build_9.8.1.201906192008.jar" id="org.eclipse.cdt.gnu.build" version="9.8.1.201906192008">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.native_8.6.0.201502131403.jar" id="org.eclipse.cdt.native" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.gnu.debug_9.8.1.201906192008.jar" id="org.eclipse.cdt.gnu.debug" version="9.8.1.201906192008">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt_8.6.0.201502131403.jar" id="org.eclipse.cdt" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.native_9.8.1.201906192008.jar" id="org.eclipse.cdt.native" version="9.8.1.201906192008">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.gnu.dsf_8.6.0.201502131403.jar" id="org.eclipse.cdt.gnu.dsf" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.platform_9.8.1.201907021957.jar" id="org.eclipse.cdt.platform" version="9.8.1.201907021957">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.gnu.build_8.6.0.201502131403.jar" id="org.eclipse.cdt.gnu.build" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.sdk_9.8.1.201907021957.jar" id="org.eclipse.cdt.sdk" version="9.8.1.201907021957">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.cdt.gnu.debug_8.6.0.201502131403.jar" id="org.eclipse.cdt.gnu.debug" version="8.6.0.201502131403">
+   <feature url="features/org.eclipse.cdt.gnu.dsf_9.8.1.201906211704.jar" id="org.eclipse.cdt.gnu.dsf" version="9.8.1.201906211704">
       <category name="com.zelgisoft.dds4ccm.cdt.category"/>
    </feature>
-   <feature url="features/org.eclipse.emf.mwe.core_1.3.4.v201409021027.jar" id="org.eclipse.emf.mwe.core" version="1.3.4.v201409021027">
-      <category name="com.zelgisoft.dds4ccm.deps.category"/>
-   </feature>
-   <feature url="features/org.eclipse.xtext.runtime_2.7.3.v201411190455.jar" id="org.eclipse.xtext.runtime" version="2.7.3.v201411190455">
+   <feature url="features/org.eclipse.xtext.runtime_2.18.0.v20190528-0716.jar" id="org.eclipse.xtext.runtime" version="2.18.0.v20190528-0716">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtext.ui_2.7.3.v201411190455.jar" id="org.eclipse.xtext.ui" version="2.7.3.v201411190455">
+   <feature url="features/org.eclipse.xtext.ui_2.18.0.v20190528-0716.jar" id="org.eclipse.xtext.ui" version="2.18.0.v20190528-0716">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtext.xbase.lib_2.7.3.v201411190455.jar" id="org.eclipse.xtext.xbase.lib" version="2.7.3.v201411190455">
+   <feature url="features/org.eclipse.xtext.xbase.lib_2.18.0.v20190528-0419.jar" id="org.eclipse.xtext.xbase.lib" version="2.18.0.v20190528-0419">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtend_2.0.0.v201406030414.jar" id="org.eclipse.xtend" version="2.0.0.v201406030414">
+   <feature url="features/org.eclipse.xtend_2.2.0.v201605260315.jar" id="org.eclipse.xtend" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtend.typesystem.uml2_2.0.0.v201406030414.jar" id="org.eclipse.xtend.typesystem.uml2" version="2.0.0.v201406030414">
+   <feature url="features/org.eclipse.xtend.typesystem.uml2_2.2.0.v201605260315.jar" id="org.eclipse.xtend.typesystem.uml2" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
-   <feature url="features/org.eclipse.xtend.typesystem.xsd_2.0.0.v201406030414.jar" id="org.eclipse.xtend.typesystem.xsd" version="2.0.0.v201406030414">
+   <feature url="features/org.eclipse.xtend.typesystem.xsd_2.2.0.v201605260315.jar" id="org.eclipse.xtend.typesystem.xsd" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
    <feature url="features/com.zeligsoft.domain.ngc.ccm.axcioma_feature_1.6.0.qualifier.jar" id="com.zeligsoft.domain.ngc.ccm.axcioma_feature" version="1.6.0.qualifier">
       <category name="com.zeligsoft.dds4ccmmaster.category"/>
    </feature>
-   <bundle id="com.google.guava" version="15.0.0.v201403281430">
+   <bundle id="org.eclipse.emf.mwe.ui" version="1.4.0">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="com.google.inject" version="3.0.0.v201312141243">
+   <bundle id="com.google.guava" version="21.0.0.v20170206-1425">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.xpand" version="2.0.0.v201406030414">
+   <bundle id="com.google.inject" version="3.0.0.v201605172100">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.xtend.shared.ui" version="2.0.0.v201406030414">
+   <bundle id="org.eclipse.xpand" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.xtend2.lib" version="2.7.3.v201411190455">
+   <bundle id="org.eclipse.xtend.shared.ui" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.emf.mwe2.runtime" version="2.7.0.v201409021027">
+   <bundle id="org.eclipse.xtend.ide" version="2.18.0.v20190528-0610">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
-   <bundle id="org.eclipse.emf.mwe.ui" version="1.3.4.v201409021027">
-      <category name="com.zelgisoft.dds4ccm.deps.category"/>
-   </bundle>
-   <bundle id="org.eclipse.xtend.lib" version="2.7.3.v201411190455">
-      <category name="com.zelgisoft.dds4ccm.deps.category"/>
-   </bundle>
-   <bundle id="org.eclipse.xtend.lib.macro" version="2.7.3.v201411190455">
+   <bundle id="org.eclipse.xtend.typesystem.emf" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
    <category-def name="com.zelgisoft.dds4ccm.cdt.category" label="CDT">
       <description>
-         Supplemental C/C++ Development tools, version 8.6. Based on Eclipse Luna (4.4),
-   and compatibile with RSA 9.5 or later.
+         Supplemental C/C++ Development tools, version 9.8.1.
       </description>
    </category-def>
    <category-def name="com.zeligsoft.dds4ccmmaster.category" label="CX CBDDS">


### PR DESCRIPTION
The update is done by considering the following changes in the project:

- Removal of 7 plugins
- Inclusion of 1 new plugin
- Removal of all dependencies to the IBM artifacts
- Inclusion of dependencies to the open-source Papyrus platform
- Inclusion of upgraded version for dependencies on the modeling tools

Also, the readme file has been changed accordingly.