### PR TITLE
Include git hash and tag values to the generated rpm names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
 script:
 - echo Built releng/com.zeligsoft.dds4ccm.update.atcd/target/dds4ccm_*.v*.zip
 - echo Built releng/com.zeligsoft.dds4ccm.update.axcioma/target/dds4ccm_*.v*.zip
-- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.axcioma" releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
-- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.atcd" releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
+- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.axcioma" --define "_travis_commit $TRAVIS_COMMIT" --define "_travis_tag $TRAVIS_TAG" releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
+- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.atcd" --define "_travis_commit $TRAVIS_COMMIT" --define "_travis_tag $TRAVIS_TAG" releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
 
 before_deploy:
     - "mkdir releng/com.zeligsoft.dds4ccm.update.atcd/target/archive"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
 script:
 - echo Built releng/com.zeligsoft.dds4ccm.update.atcd/target/dds4ccm_*.v*.zip
 - echo Built releng/com.zeligsoft.dds4ccm.update.axcioma/target/dds4ccm_*.v*.zip
-- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.axcioma" --define "_travis_commit $TRAVIS_COMMIT" --define "_travis_tag $TRAVIS_TAG" releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
-- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.atcd" --define "_travis_commit $TRAVIS_COMMIT" --define "_travis_tag $TRAVIS_TAG" releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
+- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.axcioma" --define "_git_commit_id $TRAVIS_COMMIT" --define "_git_tag $TRAVIS_TAG" releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
+- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.atcd" --define "_git_commit_id $TRAVIS_COMMIT" --define "_git_tag $TRAVIS_TAG" releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
 
 before_deploy:
     - "mkdir releng/com.zeligsoft.dds4ccm.update.atcd/target/archive"

--- a/releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
@@ -12,11 +12,11 @@
 
 # Set the release of the RPM according to the value of the 'parameterized' input
 # variables, or use a string constant
-%if 0%{?_travis_commit:1} && 0%{?_travis_tag:1}
-	%define rel %{_defaultRel}_%{_travis_commit}_%{_travis_tag}
+%if 0%{?_git_tag:1}
+	%define rel %{_defaultRel}_{_git_tag}
 %else
-	%if 0%{?_travis_commit:1}
-		%define rel %{_defaultRel}_%{_travis_commit}
+	%if 0%{?_git_commit_id:1}
+		%define rel %{_defaultRel}_%{_git_commit_id}
 	%else
 		%define rel %{_defaultRel}
 	%endif

--- a/releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
@@ -4,11 +4,23 @@
 # Copyright (c) Northrop Grumman Corporation 2019 -- ALL RIGHTS RESERVED
 #===============================================================================
 
-%define ifdef()   %if %{expand:%%{?%{1}:1}%%{!?%{1}:0}}
-%define ver       1.6.1
-%define rel       0.%(date "+%y%m%d%H%M")
-%define _rpmdir   %{_projectdir}/rpm_build/
-%define _targetdir %{_projectdir}/target
+%define ifdef()   	%if %{expand:%%{?%{1}:1}%%{!?%{1}:0}}
+%define ver       	1.6.1
+%define _defaultRel	0.%(date "+%y%m%d%H%M")
+%define _rpmdir   	%{_projectdir}/rpm_build/
+%define _targetdir 	%{_projectdir}/target
+
+# Set the release of the RPM according to the value of the 'parameterized' input
+# variables, or use a string constant
+%if 0%{?_travis_commit:1} && 0%{?_travis_tag:1}
+	%define rel %{_defaultRel}_%{_travis_commit}_%{_travis_tag}
+%else
+	%if 0%{?_travis_commit:1}
+		%define rel %{_defaultRel}_%{_travis_commit}
+	%else
+		%define rel %{_defaultRel}
+	%endif
+%endif
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Define packages

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
@@ -12,11 +12,11 @@
 
 # Set the release of the RPM according to the value of the 'parameterized' input
 # variables, or use a string constant
-%if 0%{?_travis_commit:1} && 0%{?_travis_tag:1}
-	%define rel %{_defaultRel}_%{_travis_commit}_%{_travis_tag}
+%if 0%{?_git_tag:1}
+	%define rel %{_defaultRel}_{_git_tag}
 %else
-	%if 0%{?_travis_commit:1}
-		%define rel %{_defaultRel}_%{_travis_commit}
+	%if 0%{?_git_commit_id:1}
+		%define rel %{_defaultRel}_%{_git_commit_id}
 	%else
 		%define rel %{_defaultRel}
 	%endif

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
@@ -4,12 +4,24 @@
 # Copyright (c) Northrop Grumman Corporation 2019 -- ALL RIGHTS RESERVED
 #===============================================================================
 
-%define ifdef()   %if %{expand:%%{?%{1}:1}%%{!?%{1}:0}}
-%define ver       1.6.1
-%define rel       0.%(date "+%y%m%d%H%M")
-%define _rpmdir   %{_projectdir}/rpm_build/
-%define _targetdir %{_projectdir}/target
+%define ifdef()   	%if %{expand:%%{?%{1}:1}%%{!?%{1}:0}}
+%define ver       	1.6.1
+%define _defaultRel	0.%(date "+%y%m%d%H%M")
+%define _rpmdir   	%{_projectdir}/rpm_build/
+%define _targetdir 	%{_projectdir}/target
 
+# Set the release of the RPM according to the value of the 'parameterized' input
+# variables, or use a string constant
+%if 0%{?_travis_commit:1} && 0%{?_travis_tag:1}
+	%define rel %{_defaultRel}_%{_travis_commit}_%{_travis_tag}
+%else
+	%if 0%{?_travis_commit:1}
+		%define rel %{_defaultRel}_%{_travis_commit}
+	%else
+		%define rel %{_defaultRel}
+	%endif
+%endif
+		
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Define packages
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
The 'rpmbuild' commands are updated by passing two new parameters: Travis commit hash and tag values. Depending on the availability of these parameters, the release field is updated in the spec files.

This closes #54.