### PR TITLE
Correct syntax for an empty Xtend function

### DIFF
--- a/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAtcd.ext
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAtcd.ext
@@ -268,7 +268,7 @@ Void visitConfigProperty(Void property, InstanceDeploymentDescription idd, Deplo
     // handle missing RegisterNaming property on Components
     // This method merely prevents an abort. It does not add
     // the missing RegisterNaming property.
-    ;
+    {};
     
 Void visitConfigProperty(CCM::CCM_Target::Property property, InstanceDeploymentDescription idd, DeploymentPart part ) :
 	let defaultSlots = createList(new java::lang::Object) :


### PR DESCRIPTION
Corrected syntax of an xtend function with no meaningful body.

Fixes # 66