### PR TITLE
Missing xmi:idref in CDP with 2-way connections

### DIFF
--- a/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAxcioma.ext
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAxcioma.ext
@@ -45,8 +45,9 @@ Void trace1(String topic, String message, Object parm) :JAVA
     com.zeligsoft.domain.ngc.ccm.descriptorgeneration.XDebugUtil.trace1(java.lang.String,java.lang.String,java.lang.Object);
 Void trace2(String topic, String message, Object parm0, Object parm1) :JAVA
     com.zeligsoft.domain.ngc.ccm.descriptorgeneration.XDebugUtil.trace2(java.lang.String,java.lang.String,java.lang.Object,java.lang.Object);
-	
-create DeploymentPlan mainTransformAxcioma(CCM::CCM_Deployment::DeploymentPlan deployment) :
+
+DeploymentPlan mainTransformAxcioma(CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment) :
 	let modelType = deployment.getModelType():
 	let instances = deployment.allocation.deployed.select( e | e.modelElement.metaType.toString() == "CCM::CCM_Implementation::CCMPart") :
 	let homeInstances = deployment.allocation.deployed.select( e | e.modelElement.metaType.toString() == "CCM::CCM_Implementation::HomeInstance") : 
@@ -54,17 +55,21 @@ create DeploymentPlan mainTransformAxcioma(CCM::CCM_Deployment::DeploymentPlan d
 	let parts = deployment.part.modelElement.typeSelect(CCMPart):
 	enableTrace("RegisterNaming") ->
 	storeGlobalVar("modelType",modelType) ->
-	this.label.add(deployment.zdlAsNamedElement().name) ->
-	this.label.add(getPath(deployment) + deployment.zdlAsNamedElement().name) ->
-	this.uuid.add(getUUID()) ->
-	this.createLocalityManagerElements() ->
+    plan.createLocalityManagerElements() ->
 	// generates localityConstraints for deployed components and deployed containerProcesses 
-	deployment.part.select( e | e.modelElement.metaType.toString() == "CCM::CCM_Deployment::ContainerProcess").select( e | e.isDeployed()).visitContainerProcess(this, deployment) -> // create locality constraints
-	instances.visit(this, deployment) -> // create component part instances, connector instances for non-local component ports and internal connections  
-	instances.visitPartForExternalConnectons(deployment, this) -> // create external connections between already created connector instances
-	homeInstances.visitHome(this, deployment) ->
-	connectors.createInstances(this, deployment) -> // create instances for DataSpace connector fragments
-	deployment.part.select( part | part.topLevelAssembly()).select( part | part.createConnections(deployment, this, part.modelElement));
+	deployment.part.select( e | e.modelElement.metaType.toString() == "CCM::CCM_Deployment::ContainerProcess").select( e | e.isDeployed()).visitContainerProcess(deployment) -> // create locality constraints
+	instances.visit(deployment) -> // create component part instances, connector instances for non-local component ports and internal connections  
+	instances.visitPartForExternalConnectons(deployment) -> // create external connections between already created connector instances
+	homeInstances.visitHome(plan, deployment) ->
+	connectors.createInstances(plan, deployment) -> // create instances for DataSpace connector fragments
+	deployment.part.select( part | part.topLevelAssembly()).select( part | part.createConnections(deployment, plan, part.modelElement)) ->
+	plan;
+
+create DeploymentPlan findOrCreateDeploymentPlan(CCM::CCM_Deployment::DeploymentPlan deployment) :
+    this.label.add(deployment.zdlAsNamedElement().name) ->
+    this.label.add(getPath(deployment) + deployment.zdlAsNamedElement().name) ->
+    this.uuid.add(getUUID())
+    ;
 
 cached Boolean topLevelAssembly( DeploymentPart part ) :
 	part.getParentPart() == null && part.nestedPart.size > 0 && part.modelElement.isComponent();
@@ -83,16 +88,16 @@ Void visit(ZMLMM::ZML_Deployments::Allocation self, DeploymentPlan deployment, L
 	let node = allocations.select(e|e.deployed.contains(process)).deployedOn.first() :
 	self.deployed.modelElement.typeSelect(CCMPart).visit(deployment, node);
 
-Void visitContainerProcess(DeploymentPart process, DeploymentPlan deployment, CCM::CCM_Deployment::DeploymentPlan zDeployment ) :
-	createPlanLocalityConstraint(process, deployment, zDeployment);
+Void visitContainerProcess(DeploymentPart process, CCM::CCM_Deployment::DeploymentPlan deployment ) :
+	createPlanLocalityConstraint(process, deployment);
 
-create PlanLocality createPlanLocalityConstraint(DeploymentPart deploymentPart, DeploymentPlan deployment, CCM::CCM_Deployment::DeploymentPlan zDeployment ) :
+create PlanLocality createPlanLocalityConstraint(DeploymentPart deploymentPart, CCM::CCM_Deployment::DeploymentPlan zDeployment ) :
+    let deployment = findOrCreateDeploymentPlan(zDeployment) :
 	let containerProcessInstance = createContainerProcessInstance(deploymentPart, zDeployment) :
 	deployment.localityConstraint.add(this) ->
 	deployment.instance.add(containerProcessInstance) ->
 	this.constraint.add(PlanLocalityKind::SameProcess) ->
-	this.constrainedInstance.add(createInstanceDeploymentDescription(containerProcessInstance)); // ->
-//	this.constrainedInstance.addAll(zDeployment.allocation.select(e | e.deployedOn == deploymentPart).deployed.createInstanceDeploymentDescription(deployment));
+	this.constrainedInstance.add(createInstanceDeploymentDescription(containerProcessInstance));
 	
 create InstanceDeploymentDescription createInstanceDeploymentDescription(DeploymentPart part, DeploymentPlan deployment) :
 	let partSN = part.getScopedName() :
@@ -182,13 +187,15 @@ create MonolithicDeploymentDescription visit(Home inst, DeploymentPlan deploymen
 	this.JavaSetAttribute("id", getUUID()) ->
 	deployment.implementation.add(this);
 
-create InstanceDeploymentDescription visit(DeploymentPart partDP, DeploymentPlan deployment, CCM::CCM_Deployment::DeploymentPlan zDeployment) :
+InstanceDeploymentDescription visit(DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment) :
+    let deployment = findOrCreateDeploymentPlan(zDeployment) :
+    let componentInstance = findOrCreateComponentInstance(partDP, zDeployment) :
 	let part = partDP.modelElement:
 	let comp_type = part.definition :
 	let interfacePortsGeneratingFragments = comp_type.ownedPort.typeSelect(InterfacePort).select(e | e.porttype.portGeneratesFragment()) :
 	let process = zDeployment.allocation.selectFirst( a | a.deployed.contains(partDP)).deployedOn :
 	let node = zDeployment.allocation.selectFirst(a | a.deployed.contains(process)).deployedOn :
-	let planLocality = createPlanLocalityConstraint(process, deployment, zDeployment):
+	let planLocality = createPlanLocalityConstraint(process, zDeployment):
 	
 	let id = partDP.getSelectedImplementation() == null ?
 		(
@@ -198,22 +205,30 @@ create InstanceDeploymentDescription visit(DeploymentPart partDP, DeploymentPlan
 		(
 			partDP.getSelectedImplementation().visit(deployment, zDeployment).id
 		) :	
-	interfacePortsGeneratingFragments.forAll(ifp | visitPortType(ifp, deployment)) ->
-	this.JavaSetAttribute("id", getUUID()) ->	
-	this.name.add(partDP.getScopedName()) ->
-	this.node.add(node.zdlAsNamedElement().name) ->
-	this.source.add(null) ->
-	this.implementation.add(id.visitInstanceImpl(this)) ->
+	interfacePortsGeneratingFragments.forAll(ifp | visitPortType(ifp, zDeployment)) ->
+	componentInstance.implementation.add(id.visitInstanceImpl(componentInstance)) ->
 	// trace0("RegisterNaming", "visit: BEFORE visitConfigProperty") ->
-	part.definition.zdlAsComponent().member.typeSelect(CORBAAttribute).visitConfigProperty(this, partDP) ->
+	part.definition.zdlAsComponent().member.typeSelect(CORBAAttribute).visitConfigProperty(componentInstance, partDP) ->
 	// trace0("RegisterNaming", "visit: AFTER  visitConfigProperty") ->
-	part.definition.zdlAsComponent().member.typeSelect(CCM::CCM_Target::Property).select(p | getModelTypeSpecificProperty("REGISTER_NAMING").matches(p.name) == false || partDP.shouldGenerateRegisterNamingTag(p)).visitConfigProperty(this, partDP) ->
-	if comp_type.getHome() != null then createHomeIdProperty(this, getHomePart(zDeployment, comp_type.getHome(), partDP)) -> 
-	deployment.instance.add(this) ->
+	part.definition.zdlAsComponent().member.typeSelect(CCM::CCM_Target::Property).select(p | getModelTypeSpecificProperty("REGISTER_NAMING").matches(p.name) == false || partDP.shouldGenerateRegisterNamingTag(p)).visitConfigProperty(componentInstance, partDP) ->
+	if comp_type.getHome() != null then createHomeIdProperty(componentInstance, getHomePart(zDeployment, comp_type.getHome(), partDP)) -> 
 	planLocality.constrainedInstance.add(partDP.createInstanceDeploymentDescription(deployment)) ->
 	
 	// Generate appropriate connector fragments for port-types only if certain conditions are met	
-    partDP.visitPartForConnectorFragments(zDeployment, deployment); 
+    partDP.visitPartForConnectorFragments(zDeployment, deployment) ->
+    
+    componentInstance;
+
+create InstanceDeploymentDescription findOrCreateComponentInstance(ComponentDeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment) :
+    let deployment = findOrCreateDeploymentPlan(zDeployment):
+    let processDP = getTargetPart(partDP):
+    let nodeDP = getTargetPart(processDP) :
+    this.JavaSetAttribute("id", getUUID()) ->   
+    this.name.add(partDP.getScopedName()) ->
+    this.node.add(nodeDP.name) ->
+    this.source.add(null) ->
+    deployment.instance.add(this);
+    // TODO: investigate whether more from visit, above should be moved into this method.
 	
 cached MonolithicImplementation getSelectedImplementation(ComponentDeploymentPart cdp ) :
 	let impls = ( cdp.modelElement.definition != null ? cdp.modelElement.definition.getMonolithicImplementations() : {} ) :
@@ -644,13 +659,10 @@ cached String usesPortName(ComponentInterface connectorDef) :
 create PlanConnectionDescription findOrCreateClientSideSyncConnection(
         ComponentDeploymentPart clientCompDP, InterfacePort receptacle,
         ComponentDeploymentPart serverCompDP, InterfacePort facet,
-        DeploymentPlan plan
-    ) :
-    // Ideal world:
-    //   let clientCompInst = findOrCreateComponentInstance(clientCompDP, plan) :
-    // Real world: we have not easily reused 'create' function, so we 'know' what visit(DeploymentPart, ...) does.
-    let clientCompInst = plan.instance.selectFirst( i | i.name.first().matches(clientCompDP.getScopedName())) :
-    let connectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, plan ) :
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
+    let clientCompInst = findOrCreateComponentInstance(clientCompDP, deployment) :
+    let connectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, deployment ) :
     let connectorPortName = receptacle.connectorType.syncProvidesPortName() :
 
     trace0("Connection", "Entering findOrCreateClientSideSyncConnection") ->
@@ -669,13 +681,10 @@ create PlanConnectionDescription findOrCreateClientSideSyncConnection(
 create PlanConnectionDescription findOrCreateClientSideAsyncConnection(
         ComponentDeploymentPart clientCompDP, InterfacePort receptacle,
         ComponentDeploymentPart serverCompDP, InterfacePort facet,
-        DeploymentPlan plan
-    ) :
-    // Ideal world:
-    //   let clientCompInst = findOrCreateComponentInstance(clientCompDP, plan) :
-    // Real world: we have not easily reused 'create' function, so we 'know' what visit(DeploymentPart, ...) does.
-    let clientCompInst = plan.instance.selectFirst( i | i.name.first().matches(clientCompDP.getScopedName())) :
-    let connectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, plan ) :
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
+    let clientCompInst = findOrCreateComponentInstance(clientCompDP, deployment) :
+    let connectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, deployment ) :
     let connectorPortName = receptacle.connectorType.asyncProvidesPortName() :
 
     trace0("Connection", "Entering findOrCreateClientSideAsyncConnection") ->
@@ -747,14 +756,14 @@ cached boolean isHomePart(NamedElement part ) :
 /**
  * External connection generation
  */
-Void visitPartForExternalConnectons(DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment, DeploymentPlan plan) :
+Void visitPartForExternalConnectons(DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment) :
 	let part = partDP.modelElement:
 	let portsForGeneration = clientSideInterfacePorts(part):
-	portsForGeneration.select(port| visitPortForExternalConnectons(partDP, port, zDeployment, plan));
+	portsForGeneration.select(port| visitPortForExternalConnectons(partDP, port, zDeployment));
 
-Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) : 
+Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment) : 
 	let terminalConnectedPortDP = getTerminalConnectedPortDP(port, partDP, deployment):
-	terminalConnectedPortDP.select(tce| visitPortForExternalConnectons(partDP, port, tce.getParentPart(), tce.modelElement, deployment, plan));
+	terminalConnectedPortDP.select(tce| visitPortForExternalConnectons(partDP, port, tce.getParentPart(), tce.modelElement, deployment));
 
 cached Allocation getDeploymentTarget(CCM::CCM_Deployment::DeploymentPlan deployment, CCMPart part):
 	deployment.allocation.select( e | e.deployed.modelElement.contains( part ));
@@ -806,7 +815,8 @@ cached List[DeploymentPart] getTerminalConnectedPortHelperDP(DeploymentPart cont
 	}} ->
 	terminalConnectedPortDP;
 
-Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, DeploymentPart connectedPartDP, InterfacePort connectedPort, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :	
+Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, DeploymentPart connectedPartDP, InterfacePort connectedPort, CCM::CCM_Deployment::DeploymentPlan deployment) :	
+    let plan = findOrCreateDeploymentPlan(deployment):
 	
 	let receptPartDP = {}:
 	let receptacle = {}:
@@ -834,9 +844,9 @@ Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, D
 	
 	// generate external connection only if 'receptPartDP' is deployed
 	if(receptPartDP.first().isDeployed() && facetPartDP.first().isDeployed()) then{
-		createClientServerConnection(receptPartDP.first(), receptacle.first(), facetPartDP.first(), facet.first(), deployment, plan)
+		createClientServerConnection(receptPartDP.first(), receptacle.first(), facetPartDP.first(), facet.first(), deployment)
 	} else if(receptPartDP.first().isDeployed()) then {
-        createClientConnectionToExternalServer(receptPartDP.first(), receptacle.first(), facetPartDP.first(), facet.first(), deployment, plan)
+        createClientConnectionToExternalServer(receptPartDP.first(), receptacle.first(), facetPartDP.first(), facet.first(), deployment)
 	} ->
 	
 	trace0("Connection", "Exiting visitPortForExternalConnectons")
@@ -851,9 +861,10 @@ cached InstanceDeploymentDescription getConnectorInstance(DeploymentPart partDP,
 create PlanConnectionDescription createClientConnectionToExternalServer(
         DeploymentPart clientCompDP, InterfacePort receptacle, 
         DeploymentPart serverCompDP, InterfacePort facet, 
-        CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
     
-    let receptacleConnectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, plan):
+    let receptacleConnectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, deployment):
     let rConnectorType = receptacle.connectorType.name:
     let fConnectorType = facet.connectorType.name:
     
@@ -871,10 +882,11 @@ create PlanConnectionDescription createClientConnectionToExternalServer(
 create PlanConnectionDescription createClientServerConnection(
         DeploymentPart clientCompDP, InterfacePort receptacle, 
         DeploymentPart serverCompDP, InterfacePort facet, 
-        CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
 	
-	let receptacleConnectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, plan):
-	let facetConnectorInstance = findOrCreateServerSideConnectorFragment(serverCompDP, facet, deployment, plan):
+	let receptacleConnectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, deployment):
+	let facetConnectorInstance = findOrCreateServerSideConnectorFragment(serverCompDP, facet, deployment):
 	let rConnectorType = receptacle.connectorType.name:
 	let fConnectorType = facet.connectorType.name:
 	
@@ -905,7 +917,7 @@ Void visitPortForConnectorFragments(DeploymentPart partDP, InterfacePort port, C
 		delegationConnectorEnd.select(
 			dce | visitPortForConnectorFragments(partDP.nestedPart.select( np | np.modelElement == dce.partWithPort).first(), dce.port, deployment, plan ))
 	}else if(!port.isConjugated) then {
-		partDP.findOrCreateServerSideConnectorFragment(port, deployment, plan)
+		partDP.findOrCreateServerSideConnectorFragment(port, deployment)
 	}
     -> trace0("Connectors", "Exiting visitPortForConnectorFragments")
 	;
@@ -919,12 +931,12 @@ cached List[InterfacePort] clientSideInterfacePorts(CCMPart partForComponent):
         .select(ip | ip.porttype.portGeneratesFragment() && ip.isConjugated);
 
 
-create InstanceDeploymentDescription findOrCreateServerSideConnectorFragment(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :
-	let portConnectorType = port.connectorType.name:
-	let target = deployment.allocation.selectFirst(e | e.deployed.contains(partDP)).deployedOn :
-	let node = deployment.allocation.selectFirst(e | e.deployed.contains(target)).deployedOn :
+create InstanceDeploymentDescription findOrCreateServerSideConnectorFragment(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
+    let serverProcessDP = getTargetPart(partDP):
+    let node = getTargetPart(serverProcessDP) :
 	let name = partDP.getConnectorFragmentScopedName(port) :	//partDP.getScopedName() + "." + port.porttype.name:
-	let id = port.porttype.getConnectorImplementationID(portConnectorType, plan):
+    let id = findOrCreateInterfacePortConnector(port.porttype, port.connectorType, deployment).id:
 	
 	this.JavaSetAttribute("id", getUUID()) ->
 	this.name.add(name) ->
@@ -948,14 +960,15 @@ create InstanceDeploymentDescription findOrCreateServerSideConnectorFragment(Dep
 create InstanceDeploymentDescription findOrCreateClientSideConnectorFragment(
         DeploymentPart clientCompDP, InterfacePort receptacle,
         DeploymentPart serverCompDP, InterfacePort facet,
-        DeploymentPlan plan ) :
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
     let clientProcessDP = getTargetPart(clientCompDP):
     let portConnectorType = facet.connectorType.name:
     let node = getTargetPart(clientProcessDP) :
     let name = clientCompDP.getScopedName() + "." + receptacle.name
           + "_" + receptacle.connectorType.name + "_for_"
           + serverCompDP.getScopedName() + "." + facet.name :
-    let id = findOrCreateInterfacePortConnector(receptacle.porttype, receptacle.connectorType, plan).id:
+    let id = findOrCreateInterfacePortConnector(receptacle.porttype, receptacle.connectorType, deployment).id:
     
     trace0("Connectors", "Entering findOrCreateClientSideConnectorFragment") ->
     trace2("Connectors", "client/recept for %s/%s", clientCompDP.name, receptacle.name)->
@@ -971,9 +984,9 @@ create InstanceDeploymentDescription findOrCreateClientSideConnectorFragment(
     /// depending on the synchronous/asynchronous capability of the port in addition to the conjugation status, create different types of connections
     
     if(receptacle.isUsedAsynchronously()) then {
-        findOrCreateClientSideAsyncConnection(clientCompDP, receptacle, serverCompDP, facet, plan)
+        findOrCreateClientSideAsyncConnection(clientCompDP, receptacle, serverCompDP, facet, deployment)
     } ->
-    findOrCreateClientSideSyncConnection(clientCompDP, receptacle, serverCompDP, facet, plan) ->
+    findOrCreateClientSideSyncConnection(clientCompDP, receptacle, serverCompDP, facet, deployment) ->
     
     if(existsUndeployedConnectedPart(clientCompDP, facet, deployment)) then{
         this.createRegisterNamingProperty(getRegisterNamingPropertyVal(clientCompDP, facet))
@@ -1002,7 +1015,8 @@ cached boolean portGeneratesFragment(PortType type) :
 /*
  * Create an AMI4CCM_Connector implementation.
  */
-create MonolithicDeploymentDescription findOrCreateInterfacePortConnector(CORBAInterface intf, ConnectorDef connectorType, DeploymentPlan deployment) :
+create MonolithicDeploymentDescription findOrCreateInterfacePortConnector(CORBAInterface intf, ConnectorDef connectorType, CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
 	let artifact = {}:
 	let modifiedInterfaceName = {}:
 	let componentFactoryParameter = {}:
@@ -1028,7 +1042,7 @@ create MonolithicDeploymentDescription findOrCreateInterfacePortConnector(CORBAI
 	executorArtifactParameter.add(intf.createProperty("EXEC_ARTIFACT", "", artifact.first().name.first(), "")) ->
 	servantArtifactParameter.add(intf.createProperty("SVNT_ARTIFACT", "", artifact.first().name.first(), "")) ->
 	//	
-	deployment.artifact.add(artifact.first()) ->
+	plan.artifact.add(artifact.first()) ->
 	this.name.add(name) ->
 	this.artifact.add(artifactRef.first()) ->
 	this.execParameter.add(componentFactoryParameter.first())->
@@ -1036,10 +1050,10 @@ create MonolithicDeploymentDescription findOrCreateInterfacePortConnector(CORBAI
 	this.execParameter.add(servantEntryPointParameter.first())->
 	this.execParameter.add(servantArtifactParameter.first())->
 	this.JavaSetAttribute("id", getUUID()) ->	
-	deployment.implementation.add(this);
+	plan.implementation.add(this);
 
-Void visitPortType(InterfacePort ip, DeploymentPlan plan) :
-    findOrCreateInterfacePortConnector(ip.porttype, ip.connectorType, plan);
+Void visitPortType(InterfacePort ip, CCM::CCM_Deployment::DeploymentPlan deployment) :
+    findOrCreateInterfacePortConnector(ip.porttype, ip.connectorType, deployment);
     	
 cached boolean isUsedSynchronously(CORBAInterface self) :
 	JAVA com.zeligsoft.domain.dds4ccm.utils.DDS4CCMUtil.isUsedSynchronously(
@@ -1071,7 +1085,7 @@ cached boolean isUsedAsynchronously(InterfacePort port) :
 	}} ->
 	isNonLocalAsync.first();	
 	
-Void visitPortType(PortType o, DeploymentPlan plan) :
+Void visitPortType(PortType o, CCM::CCM_Deployment::DeploymentPlan deployment) :
 	{};
 
 /*


### PR DESCRIPTION
If two components each have a facet (provides) port and a receptacle (uses) port, and the facets and receptacles are connected, then the generated CDP
will have a missing xmi:idref in one of the <instance>
tags have an empty xmi:idref field.

Changes:
- mainTransformAxcioma is no longer a ‘create’ function
- it delegates new create: findOrCreateDeploymentPlan.
- one ‘visit’ overload is no longer a create function.
- it delegates new create: findOrCreateComponentInstance
- For the affected code, replaced passing of output model DeploymentPlan with calls to findOrCreateDeploymentPlan.
- replaced searches of output model with calls to create functions.