### PR TITLE
Update CDP generation; correct RPM; fix update site dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ before_install:
   - sudo apt-get -y install rpm
 
 script:
-- echo Built releng/com.zeligsoft.dds4ccm.update.atcd/target/dds4ccm_*.v*.zip
+#- echo Built releng/com.zeligsoft.dds4ccm.update.atcd/target/dds4ccm_*.v*.zip
 - echo Built releng/com.zeligsoft.dds4ccm.update.axcioma/target/dds4ccm_*.v*.zip
 - rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.axcioma" releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
-- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.atcd" releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
+#- rpmbuild -ba --clean -vv --define "_projectdir $TRAVIS_BUILD_DIR/releng/com.zeligsoft.dds4ccm.update.atcd" releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
 
 before_deploy:
-    - "mkdir releng/com.zeligsoft.dds4ccm.update.atcd/target/archive"
-    - "cp releng/com.zeligsoft.dds4ccm.update.atcd/target/dds4ccm_*.v*.zip releng/com.zeligsoft.dds4ccm.update.atcd/target/archive"
+ #   - "mkdir releng/com.zeligsoft.dds4ccm.update.atcd/target/archive"
+ #   - "cp releng/com.zeligsoft.dds4ccm.update.atcd/target/dds4ccm_*.v*.zip releng/com.zeligsoft.dds4ccm.update.atcd/target/archive"
     - "mkdir releng/com.zeligsoft.dds4ccm.update.axcioma/target/archive"
     - "cp releng/com.zeligsoft.dds4ccm.update.axcioma/target/dds4ccm_*.v*.zip releng/com.zeligsoft.dds4ccm.update.axcioma/target/archive"
 
@@ -24,9 +24,9 @@ deploy:
     secure: SA6nCllZgAwm1ILqRTriCLePtlLLYr9ikSlOrJwMY1TuV/Nzu75LTO/qy2UsR1B7dDUzcglFsoJAhSSCh+YcHlwubRHvpJ1kEZh7CrE0oUZz/Lb/hTAKO6PWQWaBoZCVyDrYcs0y4rIn1snnWhfDRIhPQSt8WPFszBYlW4Ybxi7I6cjS68cK2V3U8QwIUmWGHzC79UIiZ2ibKnUXiWIziwgdd7l1oOWBoVjtm+7Lui0QFgywJrDC5uK4EuCNm51GmZz6ZD2JNHswcvo3URUfSP1ZG3P6Fa9nj3WHgXS2az5aQPWRak/pd3deDFW6jWQxzeCwZZFlvlFxbW8YRGsALqtEfisYcPxZxwAxi/744imrv3bvyQbbFC9tgOopR4bkun1BexQ8Cf3aXhzHXMeiQsZKjf+kiCkvraUz/VkfGrVuYvyQoHrWsehmg/Csl11l1GGvo2wCtKfVNkZ2s3vjdeR9cl87GyN0tm1WkuSLPgULjBgbkgENkLPSr2dGrBvsWSXComF6uhc49oqTDKeLeXE2SVcMrhomq5NZ+25EYCfK5bfGjwJ17MLI2IkRL/zwxlyQTMRRkZGnICtR+zcniRLDucAsgJ98zm7vkN06pK1AI7ZvPemp+yya33iGlcPSpU/RKEU8HW6PiH8s1AX8TwfVrknHwXxrn4MUKLWQV5I=
   file_glob: true
   file: 
-    - releng/com.zeligsoft.dds4ccm.update.atcd/target/archive/*
+ #   - releng/com.zeligsoft.dds4ccm.update.atcd/target/archive/*
     - releng/com.zeligsoft.dds4ccm.update.axcioma/target/archive/*
-    - releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/noarch/*.rpm
+ #   - releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/noarch/*.rpm
     - releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/noarch/*.rpm
   on:
     repo: ZeligsoftDev/CX4CBDDS

--- a/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAxcioma.ext
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAxcioma.ext
@@ -45,8 +45,9 @@ Void trace1(String topic, String message, Object parm) :JAVA
     com.zeligsoft.domain.ngc.ccm.descriptorgeneration.XDebugUtil.trace1(java.lang.String,java.lang.String,java.lang.Object);
 Void trace2(String topic, String message, Object parm0, Object parm1) :JAVA
     com.zeligsoft.domain.ngc.ccm.descriptorgeneration.XDebugUtil.trace2(java.lang.String,java.lang.String,java.lang.Object,java.lang.Object);
-	
-create DeploymentPlan mainTransformAxcioma(CCM::CCM_Deployment::DeploymentPlan deployment) :
+
+DeploymentPlan mainTransformAxcioma(CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment) :
 	let modelType = deployment.getModelType():
 	let instances = deployment.allocation.deployed.select( e | e.modelElement.metaType.toString() == "CCM::CCM_Implementation::CCMPart") :
 	let homeInstances = deployment.allocation.deployed.select( e | e.modelElement.metaType.toString() == "CCM::CCM_Implementation::HomeInstance") : 
@@ -54,17 +55,21 @@ create DeploymentPlan mainTransformAxcioma(CCM::CCM_Deployment::DeploymentPlan d
 	let parts = deployment.part.modelElement.typeSelect(CCMPart):
 	enableTrace("RegisterNaming") ->
 	storeGlobalVar("modelType",modelType) ->
-	this.label.add(deployment.zdlAsNamedElement().name) ->
-	this.label.add(getPath(deployment) + deployment.zdlAsNamedElement().name) ->
-	this.uuid.add(getUUID()) ->
-	this.createLocalityManagerElements() ->
+    plan.createLocalityManagerElements() ->
 	// generates localityConstraints for deployed components and deployed containerProcesses 
-	deployment.part.select( e | e.modelElement.metaType.toString() == "CCM::CCM_Deployment::ContainerProcess").select( e | e.isDeployed()).visitContainerProcess(this, deployment) -> // create locality constraints
-	instances.visit(this, deployment) -> // create component part instances, connector instances for non-local component ports and internal connections  
-	instances.visitPartForExternalConnectons(deployment, this) -> // create external connections between already created connector instances
-	homeInstances.visitHome(this, deployment) ->
-	connectors.createInstances(this, deployment) -> // create instances for DataSpace connector fragments
-	deployment.part.select( part | part.topLevelAssembly()).select( part | part.createConnections(deployment, this, part.modelElement));
+	deployment.part.select( e | e.modelElement.metaType.toString() == "CCM::CCM_Deployment::ContainerProcess").select( e | e.isDeployed()).visitContainerProcess(deployment) -> // create locality constraints
+	instances.visit(deployment) -> // create component part instances, connector instances for non-local component ports and internal connections  
+	instances.visitPartForExternalConnectons(deployment) -> // create external connections between already created connector instances
+	homeInstances.visitHome(plan, deployment) ->
+	connectors.createInstances(plan, deployment) -> // create instances for DataSpace connector fragments
+	deployment.part.select( part | part.topLevelAssembly()).select( part | part.createConnections(deployment, plan, part.modelElement)) ->
+	plan;
+
+create DeploymentPlan findOrCreateDeploymentPlan(CCM::CCM_Deployment::DeploymentPlan deployment) :
+    this.label.add(deployment.zdlAsNamedElement().name) ->
+    this.label.add(getPath(deployment) + deployment.zdlAsNamedElement().name) ->
+    this.uuid.add(getUUID())
+    ;
 
 cached Boolean topLevelAssembly( DeploymentPart part ) :
 	part.getParentPart() == null && part.nestedPart.size > 0 && part.modelElement.isComponent();
@@ -83,16 +88,16 @@ Void visit(ZMLMM::ZML_Deployments::Allocation self, DeploymentPlan deployment, L
 	let node = allocations.select(e|e.deployed.contains(process)).deployedOn.first() :
 	self.deployed.modelElement.typeSelect(CCMPart).visit(deployment, node);
 
-Void visitContainerProcess(DeploymentPart process, DeploymentPlan deployment, CCM::CCM_Deployment::DeploymentPlan zDeployment ) :
-	createPlanLocalityConstraint(process, deployment, zDeployment);
+Void visitContainerProcess(DeploymentPart process, CCM::CCM_Deployment::DeploymentPlan deployment ) :
+	createPlanLocalityConstraint(process, deployment);
 
-create PlanLocality createPlanLocalityConstraint(DeploymentPart deploymentPart, DeploymentPlan deployment, CCM::CCM_Deployment::DeploymentPlan zDeployment ) :
+create PlanLocality createPlanLocalityConstraint(DeploymentPart deploymentPart, CCM::CCM_Deployment::DeploymentPlan zDeployment ) :
+    let deployment = findOrCreateDeploymentPlan(zDeployment) :
 	let containerProcessInstance = createContainerProcessInstance(deploymentPart, zDeployment) :
 	deployment.localityConstraint.add(this) ->
 	deployment.instance.add(containerProcessInstance) ->
 	this.constraint.add(PlanLocalityKind::SameProcess) ->
-	this.constrainedInstance.add(createInstanceDeploymentDescription(containerProcessInstance)); // ->
-//	this.constrainedInstance.addAll(zDeployment.allocation.select(e | e.deployedOn == deploymentPart).deployed.createInstanceDeploymentDescription(deployment));
+	this.constrainedInstance.add(createInstanceDeploymentDescription(containerProcessInstance));
 	
 create InstanceDeploymentDescription createInstanceDeploymentDescription(DeploymentPart part, DeploymentPlan deployment) :
 	let partSN = part.getScopedName() :
@@ -181,14 +186,16 @@ create MonolithicDeploymentDescription visit(Home inst, DeploymentPlan deploymen
 	this.execParameter.add(inst.visitImplementationTypeParameter(impl)) ->
 	this.JavaSetAttribute("id", getUUID()) ->
 	deployment.implementation.add(this);
-		
-create InstanceDeploymentDescription visit(DeploymentPart partDP, DeploymentPlan deployment, CCM::CCM_Deployment::DeploymentPlan zDeployment) :
+
+InstanceDeploymentDescription visit(DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment) :
+    let deployment = findOrCreateDeploymentPlan(zDeployment) :
+    let componentInstance = findOrCreateComponentInstance(partDP, zDeployment) :
 	let part = partDP.modelElement:
 	let comp_type = part.definition :
 	let interfacePortsGeneratingFragments = comp_type.ownedPort.typeSelect(InterfacePort).select(e | e.porttype.portGeneratesFragment()) :
 	let process = zDeployment.allocation.selectFirst( a | a.deployed.contains(partDP)).deployedOn :
 	let node = zDeployment.allocation.selectFirst(a | a.deployed.contains(process)).deployedOn :
-	let planLocality = createPlanLocalityConstraint(process, deployment, zDeployment):
+	let planLocality = createPlanLocalityConstraint(process, zDeployment):
 	
 	let id = partDP.getSelectedImplementation() == null ?
 		(
@@ -198,22 +205,30 @@ create InstanceDeploymentDescription visit(DeploymentPart partDP, DeploymentPlan
 		(
 			partDP.getSelectedImplementation().visit(deployment, zDeployment).id
 		) :	
-	interfacePortsGeneratingFragments.forAll(ifp | visitPortType(ifp, deployment)) ->
-	this.JavaSetAttribute("id", getUUID()) ->	
-	this.name.add(partDP.getScopedName()) ->
-	this.node.add(node.zdlAsNamedElement().name) ->
-	this.source.add(null) ->
-	this.implementation.add(id.visitInstanceImpl(this)) ->
+	interfacePortsGeneratingFragments.forAll(ifp | visitPortType(ifp, zDeployment)) ->
+	componentInstance.implementation.add(id.visitInstanceImpl(componentInstance)) ->
 	// trace0("RegisterNaming", "visit: BEFORE visitConfigProperty") ->
-	part.definition.zdlAsComponent().member.typeSelect(CORBAAttribute).visitConfigProperty(this, partDP) ->
+	part.definition.zdlAsComponent().member.typeSelect(CORBAAttribute).visitConfigProperty(componentInstance, partDP) ->
 	// trace0("RegisterNaming", "visit: AFTER  visitConfigProperty") ->
-	part.definition.zdlAsComponent().member.typeSelect(CCM::CCM_Target::Property).select(p | getModelTypeSpecificProperty("REGISTER_NAMING").matches(p.name) == false || partDP.shouldGenerateRegisterNamingTag(p)).visitConfigProperty(this, partDP) ->
-	if comp_type.getHome() != null then createHomeIdProperty(this, getHomePart(zDeployment, comp_type.getHome(), partDP)) -> 
-	deployment.instance.add(this) ->
+	part.definition.zdlAsComponent().member.typeSelect(CCM::CCM_Target::Property).select(p | getModelTypeSpecificProperty("REGISTER_NAMING").matches(p.name) == false || partDP.shouldGenerateRegisterNamingTag(p)).visitConfigProperty(componentInstance, partDP) ->
+	if comp_type.getHome() != null then createHomeIdProperty(componentInstance, getHomePart(zDeployment, comp_type.getHome(), partDP)) -> 
 	planLocality.constrainedInstance.add(partDP.createInstanceDeploymentDescription(deployment)) ->
 	
 	// Generate appropriate connector fragments for port-types only if certain conditions are met	
-    partDP.visitPartForConnectorFragments(zDeployment, deployment); 
+    partDP.visitPartForConnectorFragments(zDeployment, deployment) ->
+    
+    componentInstance;
+
+create InstanceDeploymentDescription findOrCreateComponentInstance(ComponentDeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment) :
+    let deployment = findOrCreateDeploymentPlan(zDeployment):
+    let processDP = getTargetPart(partDP):
+    let nodeDP = getTargetPart(processDP) :
+    this.JavaSetAttribute("id", getUUID()) ->   
+    this.name.add(partDP.getScopedName()) ->
+    this.node.add(nodeDP.name) ->
+    this.source.add(null) ->
+    deployment.instance.add(this);
+    // TODO: investigate whether more from visit, above should be moved into this method.
 	
 cached MonolithicImplementation getSelectedImplementation(ComponentDeploymentPart cdp ) :
 	let impls = ( cdp.modelElement.definition != null ? cdp.modelElement.definition.getMonolithicImplementations() : {} ) :
@@ -286,10 +301,10 @@ Void visitConfigProperty(CCM::CCM_Target::Property property, InstanceDeploymentD
 		
 		// Register naming tag must be generated even if no values set
 		//
-		// IF there占퐏 no explicit RegisterNaming property set on either the CCMComponent type (default setting) 
+		// IF there�s no explicit RegisterNaming property set on either the CCMComponent type (default setting) 
 		// OR on the instance of that type (override setting) in the deployment plan, 
-		// BUT there占퐏 a CCMConnector connection definition in the deployment assembly that 
-		// connects a deployed component instance (any facet/receptacle port 占� just takes one) 
+		// BUT there�s a CCMConnector connection definition in the deployment assembly that 
+		// connects a deployed component instance (any facet/receptacle port � just takes one) 
 		// with a non-deployed component instance, then generate the register naming tag for the deployed instance.
 		if(property.name == getModelTypeSpecificProperty("REGISTER_NAMING") && !idd.configProperty.name.exists(n | n == property.name)) then {
 			idd.createRegisterNamingProperty(part.name)
@@ -604,22 +619,6 @@ create Any createRegisterNamingProperty(Property property, String val ) :
 	this.value.add(value);
 
 /*
- * Axcioma (async): Connection between sendC of Recept and connector. Both in client side.
- */
-create PlanConnectionDescription createAsyncClientSideSendcConnection(InstanceDeploymentDescription idd, DeploymentPart source, InterfacePort receptacle, DeploymentPlan plan) :
-	let sourceSN = source.getScopedName() :
-	let compInstance = plan.instance.selectFirst( i | i.name.first().matches(sourceSN)) :
-	let receptacleConnectorType = receptacle.connectorType.name:
-	let portNameOfConnectorInstance = getConnectorProvidesPortName(receptacle).first():
-	
-	if(receptacleConnectorType == "AMI4CCM_Connector") then{
-		this.name.add(sourceSN + "." + receptacle.name + "::" + idd.name.first() + "." + portNameOfConnectorInstance) ->
-		this.createEndPoint(true, false, portNameOfConnectorInstance, idd) ->
-		// AMI Fragment connections are never multiplex.
-		this.createEndPoint(false, false, "sendc_" + receptacle.name, compInstance)
-	};
-
-/*
 * Depending on the given connectorType, return corresponding 'provides' port name
 */
 cached List[String] getConnectorProvidesPortName(InterfacePort port):
@@ -640,33 +639,64 @@ cached List[String] getConnectorProvidesPortName(InterfacePort port):
 * Depending on the given connectorType, return corresponding 'uses' port name
 */
 cached String getConnectorUsesPortName(InterfacePort port):
-	let connectorType = port.connectorType.name:
-	let portName = {}:
-	{if(connectorType == "AMI4CCM_Connector") then{
-		portName.add("ami4ccm_port_ami4ccm_uses")
-	}else if(connectorType == "CORBA4CCM_Connector") then{
-		portName.add("srr_receptacle")
-	}else{
-	// this should never be entered given we pass a valid connectorType
-		portName.add("")
-	}} ->
-	portName.first();
-		
-/*
- * Axcioma (Async port): Connection between sync_provides of the connector instance and Recept. Both in client side.
- */	
-create PlanConnectionDescription createAsyncClientSideSyncProvidesConnection(InstanceDeploymentDescription idd, DeploymentPart source, InterfacePort receptacle, DeploymentPlan plan) :
-	let sourceSN = source.getScopedName() :
-	let receptacleConnectorType = receptacle.connectorType.name:
-	let compInstance = plan.instance.selectFirst( i | i.name.first().matches(sourceSN)) :
-	let portNameOfConnectorInstance = getConnectorProvidesPortName(receptacle).get(1): // for ami4ccm, the returned list will have 2 entries
-	
-	if(receptacleConnectorType == "AMI4CCM_Connector") then{
-		this.name.add(sourceSN + "." + receptacle.name + "::" + idd.name.first() + "." + portNameOfConnectorInstance) ->
-		this.createEndPoint(false, false, receptacle.name, compInstance) ->
-		// AMI Fragment connections are never multiplex.
-		this.createEndPoint(true, false, portNameOfConnectorInstance, idd)
-	};
+	usesPortName(port.connectorType);
+
+cached String syncProvidesPortName(ComponentInterface connectorDef) :
+    connectorDef.name == "AMI4CCM_Connector" 
+        ? "ami4ccm_port_ami4ccm_sync_provides"
+        : "srr_facet";
+
+cached String asyncProvidesPortName(ComponentInterface connectorDef) :
+    connectorDef.name == "AMI4CCM_Connector" 
+        ? "ami4ccm_port_ami4ccm_provides"
+        : "<error:no async provides for " + connectorDef.name + ">"; 
+
+cached String usesPortName(ComponentInterface connectorDef) :
+    connectorDef.name == "AMI4CCM_Connector" 
+        ? "ami4ccm_port_ami4ccm_uses"
+        : "srr_receptacle";
+
+create PlanConnectionDescription findOrCreateClientSideSyncConnection(
+        ComponentDeploymentPart clientCompDP, InterfacePort receptacle,
+        ComponentDeploymentPart serverCompDP, InterfacePort facet,
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
+    let clientCompInst = findOrCreateComponentInstance(clientCompDP, deployment) :
+    let connectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, deployment ) :
+    let connectorPortName = receptacle.connectorType.syncProvidesPortName() :
+
+    trace0("Connection", "Entering findOrCreateClientSideSyncConnection") ->
+    trace2("Connection", "Client %s.%s", clientCompDP.name, receptacle.name) ->
+    trace2("Connection", "Server %s.%s", serverCompDP.name, facet.name) ->
+
+    this.name.add(clientCompInst.name.first() + "." + receptacle.name 
+        + "::" + connectorInstance.name.first() + "." + connectorPortName) ->
+    this.createEndPoint(false, true, receptacle.name, clientCompInst) ->
+    this.createEndPoint(true, false, connectorPortName, connectorInstance) ->
+    
+    trace1("Connection", "ClientSide Sync %s", this.name) ->
+    
+    plan.connection.add(this);
+
+create PlanConnectionDescription findOrCreateClientSideAsyncConnection(
+        ComponentDeploymentPart clientCompDP, InterfacePort receptacle,
+        ComponentDeploymentPart serverCompDP, InterfacePort facet,
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
+    let clientCompInst = findOrCreateComponentInstance(clientCompDP, deployment) :
+    let connectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, deployment ) :
+    let connectorPortName = receptacle.connectorType.asyncProvidesPortName() :
+
+    trace0("Connection", "Entering findOrCreateClientSideAsyncConnection") ->
+
+    this.name.add( clientCompInst.name.first() + "." + receptacle.name 
+        + "::" + connectorInstance.name.first() + "." + connectorPortName) ->
+    this.createEndPoint(false, false, "sendc_" + receptacle.name, clientCompInst) ->
+    this.createEndPoint(true, false, connectorPortName, connectorInstance) ->
+
+    trace1("Connection", "ClientSide ASync %s", this.name) ->
+    
+    plan.connection.add(this);
 	
 create PlanSubcomponentPortEndpoint createEndPoint(PlanConnectionDescription conn, Boolean provides, Boolean multiple, String portName, InstanceDeploymentDescription instance ) :
 	this.portName.add(portName) ->
@@ -699,25 +729,6 @@ create ExternalReferenceEndpoint createExternalEndPoint(PlanConnectionDescriptio
 	connDescription.externalReference.add(this);
 	
 /*
- * Axcioma: connection between recept and srr_facet. Both in client side.
- */	
-create PlanConnectionDescription createSyncClientSideConnection(InstanceDeploymentDescription idd, DeploymentPart source, InterfacePort receptacle, DeploymentPlan plan) :
-	let sourceSN = source.getScopedName() :
-	let compInstance = plan.instance.selectFirst( i | i.name.first().matches(sourceSN)) :
-	let receptacleConnectorType = receptacle.connectorType.name:
-	let portNameOfConnectorInstance = getConnectorProvidesPortName(receptacle).first(): 
-	
-	this.name.add(sourceSN + "." + receptacle.name + "::" + idd.name.first() + "." + portNameOfConnectorInstance) ->
-	{if(receptacleConnectorType == "AMI4CCM_Connector") then{
-	// the only facet used from AMI4CCM connector in sync connection is 'ami4ccm_port_ami4ccm_sync_provides' 
-		this.createEndPoint(false, false, receptacle.name, compInstance)
-	}else{
-		this.createEndPoint(false, true, receptacle.name, compInstance)
-	}} ->
-		
-	// AMI Fragment connections are never multiplex.
-	this.createEndPoint(true, false, portNameOfConnectorInstance, idd);	
-/*
  * Axcioma: Connection between srr_receptacle and facet. Both in server side 
  */	
 create PlanConnectionDescription createServerSideConnection(InstanceDeploymentDescription srrInstance, 
@@ -745,14 +756,14 @@ cached boolean isHomePart(NamedElement part ) :
 /**
  * External connection generation
  */
-Void visitPartForExternalConnectons(DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment, DeploymentPlan plan) :
+Void visitPartForExternalConnectons(DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment) :
 	let part = partDP.modelElement:
-	let portsForGeneration = getPortsForGeneration(part):
-	portsForGeneration.select(port| visitPortForExternalConnectons(partDP, port, zDeployment, plan));
+	let portsForGeneration = clientSideInterfacePorts(part):
+	portsForGeneration.select(port| visitPortForExternalConnectons(partDP, port, zDeployment));
 
-Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) : 
+Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment) : 
 	let terminalConnectedPortDP = getTerminalConnectedPortDP(port, partDP, deployment):
-	terminalConnectedPortDP.select(tce| visitPortForExternalConnectons(partDP, port, tce.getParentPart(), tce.modelElement, deployment, plan));
+	terminalConnectedPortDP.select(tce| visitPortForExternalConnectons(partDP, port, tce.getParentPart(), tce.modelElement, deployment));
 
 cached Allocation getDeploymentTarget(CCM::CCM_Deployment::DeploymentPlan deployment, CCMPart part):
 	deployment.allocation.select( e | e.deployed.modelElement.contains( part ));
@@ -804,12 +815,17 @@ cached List[DeploymentPart] getTerminalConnectedPortHelperDP(DeploymentPart cont
 	}} ->
 	terminalConnectedPortDP;
 
-Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, DeploymentPart connectedPartDP, InterfacePort connectedPort, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :	
+Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, DeploymentPart connectedPartDP, InterfacePort connectedPort, CCM::CCM_Deployment::DeploymentPlan deployment) :	
+    let plan = findOrCreateDeploymentPlan(deployment):
 	
 	let receptPartDP = {}:
 	let receptacle = {}:
 	let facetPartDP = {}:
 	let facet = {}:
+	
+	trace0("Connection", "Entering visitPortForExternalConnectons") ->
+	trace2("Connection", "partDP(port) = %s(%s)", partDP.name, port.name) ->
+	trace2("Connection", "connectedPartDP(connectedPort) = %s(%s)", connectedPartDP.name, connectedPort.name) ->
 	
 	{if(port.isConjugated) then{
 		receptPartDP.add(partDP) ->
@@ -822,11 +838,19 @@ Void visitPortForExternalConnectons(DeploymentPart partDP, InterfacePort port, D
 		facetPartDP.add(partDP) ->
 		facet.add(port)
 	}} ->	
+
+    trace2("Connection", "receptPartDP(receptacle) = %s(%s)", receptPartDP.first().name, receptacle.first().name) ->
+    trace2("Connection", "facetPartDP(facet) = %s(%s)", facetPartDP.first().name, facet.first().name) ->
 	
 	// generate external connection only if 'receptPartDP' is deployed
-	if(receptPartDP.first().isDeployed()) then{
-		createClientServerConnection(receptPartDP.first(), receptacle.first(), facetPartDP.first(), facet.first(), plan)
-	};
+	if(receptPartDP.first().isDeployed() && facetPartDP.first().isDeployed()) then{
+		createClientServerConnection(receptPartDP.first(), receptacle.first(), facetPartDP.first(), facet.first(), deployment)
+	} else if(receptPartDP.first().isDeployed()) then {
+        createClientConnectionToExternalServer(receptPartDP.first(), receptacle.first(), facetPartDP.first(), facet.first(), deployment)
+	} ->
+	
+	trace0("Connection", "Exiting visitPortForExternalConnectons")
+	;
 	
 	
 // return connetorInstance corresponding to the 'port' owned by the 'part' 	
@@ -834,54 +858,85 @@ cached InstanceDeploymentDescription getConnectorInstance(DeploymentPart partDP,
 	let connectorFragmentSN = partDP.getConnectorFragmentScopedName(port):
 	plan.instance.selectFirst( i | i.name.first().matches(connectorFragmentSN));
 
-create PlanConnectionDescription createClientServerConnection(DeploymentPart receptPartDP, InterfacePort receptacle, DeploymentPart facetPartDP, InterfacePort facet, DeploymentPlan plan) :
+create PlanConnectionDescription createClientConnectionToExternalServer(
+        DeploymentPart clientCompDP, InterfacePort receptacle, 
+        DeploymentPart serverCompDP, InterfacePort facet, 
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
+    
+    let receptacleConnectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, deployment):
+    let rConnectorType = receptacle.connectorType.name:
+    let fConnectorType = facet.connectorType.name:
+    
+    trace0("Connection", "Entering createClientConnectionToExternalServer") ->
+
+    this.name.add(clientCompDP.getScopedName() + "." + receptacle.name + '_' + rConnectorType + "__" + serverCompDP.getScopedName() + "." + facet.name + "_" + fConnectorType  
+            + (receptacle.isUsedSynchronously()? "_syncdirect" : "_asyncdirect")) ->
+    this.createEndPoint(false, false, getConnectorUsesPortName(receptacle), receptacleConnectorInstance) ->
+    this.createExternalEndPoint(getRegisterNamingPropertyVal(serverCompDP, facet), facet, serverCompDP) ->
+    plan.connection.add(this) ->
+    
+    trace1("Connection", "Client to external Server: %s", this.name) ->
+    this;
+
+create PlanConnectionDescription createClientServerConnection(
+        DeploymentPart clientCompDP, InterfacePort receptacle, 
+        DeploymentPart serverCompDP, InterfacePort facet, 
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
 	
-	let receptacleConnectorInstance = getConnectorInstance(receptPartDP, receptacle, deployment, plan):
-	let facetConnectorInstance = getConnectorInstance(facetPartDP, facet, deployment, plan):
+	let receptacleConnectorInstance = findOrCreateClientSideConnectorFragment(clientCompDP, receptacle, serverCompDP, facet, deployment):
+	let facetConnectorInstance = findOrCreateServerSideConnectorFragment(serverCompDP, facet, deployment):
 	let rConnectorType = receptacle.connectorType.name:
 	let fConnectorType = facet.connectorType.name:
 	
-	{if(receptPartDP.isDeployed() && facetPartDP.isDeployed()) then{
-		this.name.add(receptacleConnectorInstance.name.first() + "." + getConnectorUsesPortName(receptacle) + "::" + 
-			facetConnectorInstance.name.first() + "." + getConnectorProvidesPortName(facet).first()) ->
-		this.createEndPoint(false, false, getConnectorUsesPortName(receptacle), receptacleConnectorInstance) ->
-		this.createEndPoint(true, false, getConnectorProvidesPortName(facet).first(), facetConnectorInstance)
-	}else if(receptPartDP.isDeployed()) then{
-		this.name.add(receptPartDP.getScopedName() + "." + receptacle.name + '_' + rConnectorType + "__" + facetPartDP.getScopedName() + "." + facet.name + "_" + fConnectorType  
-				+ (receptacle.isUsedSynchronously()? "_syncdirect" : "_asyncdirect")) ->
-		this.createEndPoint(false, false, getConnectorUsesPortName(receptacle), receptacleConnectorInstance) ->
-		this.createExternalEndPoint(getRegisterNamingPropertyVal(facetPartDP, facet), facet, facetPartDP)
-	}}->
+	trace0("Connection", "Entering createClientServerConnection") ->
+    this.name.add(receptacleConnectorInstance.name.first() + "." + getConnectorUsesPortName(receptacle) + "::" + 
+		facetConnectorInstance.name.first() + "." + getConnectorProvidesPortName(facet).first()) ->
+	this.createEndPoint(false, false, getConnectorUsesPortName(receptacle), receptacleConnectorInstance) ->
+	this.createEndPoint(true, false, getConnectorProvidesPortName(facet).first(), facetConnectorInstance)->
 	plan.connection.add(this) ->
+	
+	trace1("Connection", "Client Server: %s", this.name) ->
 	this;
 
 Void visitPartForConnectorFragments(DeploymentPart partDP, CCM::CCM_Deployment::DeploymentPlan zDeployment, DeploymentPlan plan) :
 	let part = partDP.modelElement:
-	let portsForGeneration = getPortsForGeneration(part):
+	let portsForGeneration = serverSideInterfacePorts(part):
 	portsForGeneration.select(port| visitPortForConnectorFragments(partDP, port, zDeployment, plan));
 
 Void visitPortForConnectorFragments(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :
 	let part = partDP.modelElement:
 	let component = part.definition :
 	let assembly_impl = getAssembly(component) :
+	
+	trace0("Connectors", "Entering visitPortForConnectorFragments") ->
 	if( assembly_impl.size > 0 ) then {	
 		let delegationConnectorEnd = assembly_impl.connector.select( c | c.end.port.contains(port)).end.reject( c | c.port == port ) :
 		// Recursive call with new values for part and port, and same values for everything else.
 		delegationConnectorEnd.select(
 			dce | visitPortForConnectorFragments(partDP.nestedPart.select( np | np.modelElement == dce.partWithPort).first(), dce.port, deployment, plan ))
-	}else{
-		partDP.createInternalConnectorFragments(port, deployment, plan)
-	};
+	}else if(!port.isConjugated) then {
+		partDP.findOrCreateServerSideConnectorFragment(port, deployment)
+	}
+    -> trace0("Connectors", "Exiting visitPortForConnectorFragments")
+	;
 
-cached List[InterfacePort] getPortsForGeneration(CCMPart part):
-	part.definition.ownedPort.typeSelect(InterfacePort).select(e | e.porttype.portGeneratesFragment());	
+cached List[InterfacePort] serverSideInterfacePorts(CCMPart partForComponent):
+    partForComponent.definition.ownedPort.typeSelect(InterfacePort)
+        .select(ip | ip.porttype.portGeneratesFragment() && !ip.isConjugated);
 
-create InstanceDeploymentDescription createInternalConnectorFragments(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment, DeploymentPlan plan) :
-	let portConnectorType = port.connectorType.name:
-	let target = deployment.allocation.selectFirst(e | e.deployed.contains(partDP)).deployedOn :
-	let node = deployment.allocation.selectFirst(e | e.deployed.contains(target)).deployedOn :
-	let name = 	partDP.getConnectorFragmentScopedName(port) :	//partDP.getScopedName() + "." + port.porttype.name:
-	let id = port.porttype.getConnectorImplementationID(portConnectorType, plan):
+cached List[InterfacePort] clientSideInterfacePorts(CCMPart partForComponent):
+    partForComponent.definition.ownedPort.typeSelect(InterfacePort)
+        .select(ip | ip.porttype.portGeneratesFragment() && ip.isConjugated);
+
+
+create InstanceDeploymentDescription findOrCreateServerSideConnectorFragment(DeploymentPart partDP, InterfacePort port, CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
+    let serverProcessDP = getTargetPart(partDP):
+    let node = getTargetPart(serverProcessDP) :
+	let name = partDP.getConnectorFragmentScopedName(port) :	//partDP.getScopedName() + "." + port.porttype.name:
+    let id = findOrCreateInterfacePortConnector(port.porttype, port.connectorType, deployment).id:
 	
 	this.JavaSetAttribute("id", getUUID()) ->
 	this.name.add(name) ->
@@ -890,29 +945,56 @@ create InstanceDeploymentDescription createInternalConnectorFragments(Deployment
 	this.implementation.add(id.visitInstanceImpl(this)) ->
 	plan.instance.add(this) ->
 	
-	/// depending on the synchronous/asynchronous capability of the port in addition to the conjugation status, create different types of connections
-	
-	{if (port.isConjugated) then{
-		
-		{if(port.isUsedAsynchronously() && (portConnectorType == "AMI4CCM_Connector")) then{
-			plan.connection.add(this.createAsyncClientSideSendcConnection(partDP, port, plan)) ->
-			plan.connection.add(this.createAsyncClientSideSyncProvidesConnection(partDP, port, plan))
-		
-		}else if(port.isUsedSynchronously()  && (portConnectorType == "AMI4CCM_Connector")) then{
-			plan.connection.add(this.createAsyncClientSideSyncProvidesConnection(partDP, port, plan))
-		
-		}else if(port.isUsedSynchronously()  && (portConnectorType == "CORBA4CCM_Connector")) then{
-			plan.connection.add(this.createSyncClientSideConnection(partDP, port, plan))
-		}}
-	}else{
-		plan.connection.add(this.createServerSideConnection(partDP, port, plan))	
-	}} ->
+	plan.connection.add(this.createServerSideConnection(partDP, port, plan))	
+	->
 	
 	if(existsUndeployedConnectedPart(partDP, port, deployment)) then{
 		this.createRegisterNamingProperty(getRegisterNamingPropertyVal(partDP, port))
 	} ->
 	
+    trace1("Connectors", "ServerSide %s", this.name) ->
+    
 	addInstanceToLocalityConstraint(this, plan, partDP);
+
+
+create InstanceDeploymentDescription findOrCreateClientSideConnectorFragment(
+        DeploymentPart clientCompDP, InterfacePort receptacle,
+        DeploymentPart serverCompDP, InterfacePort facet,
+        CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
+    let clientProcessDP = getTargetPart(clientCompDP):
+    let portConnectorType = facet.connectorType.name:
+    let node = getTargetPart(clientProcessDP) :
+    let name = clientCompDP.getScopedName() + "." + receptacle.name
+          + "_" + receptacle.connectorType.name + "_for_"
+          + serverCompDP.getScopedName() + "." + facet.name :
+    let id = findOrCreateInterfacePortConnector(receptacle.porttype, receptacle.connectorType, deployment).id:
+    
+    trace0("Connectors", "Entering findOrCreateClientSideConnectorFragment") ->
+    trace2("Connectors", "client/recept for %s/%s", clientCompDP.name, receptacle.name)->
+    trace2("Connectors", "server/facet for %s/%s", serverCompDP.name, facet.name)->
+    trace2("Connectors", "process/node %s/%s", clientProcessDP.name, node.name)->
+    this.JavaSetAttribute("id", getUUID()) ->
+    this.name.add(name) ->
+    this.node.add(node.name) ->
+    this.source.add(null) ->
+    this.implementation.add(id.visitInstanceImpl(this)) ->
+    plan.instance.add(this) ->
+    
+    /// depending on the synchronous/asynchronous capability of the port in addition to the conjugation status, create different types of connections
+    
+    if(receptacle.isUsedAsynchronously()) then {
+        findOrCreateClientSideAsyncConnection(clientCompDP, receptacle, serverCompDP, facet, deployment)
+    } ->
+    findOrCreateClientSideSyncConnection(clientCompDP, receptacle, serverCompDP, facet, deployment) ->
+    
+    if(existsUndeployedConnectedPart(clientCompDP, facet, deployment)) then{
+        this.createRegisterNamingProperty(getRegisterNamingPropertyVal(clientCompDP, facet))
+    } ->
+    
+    trace1("Connectors", "ClientSide %s", this.name) ->
+    
+    addInstanceToLocalityConstraint(this, plan, clientCompDP);
 	
 cached String getRegisterNamingPropertyVal(DeploymentPart partDP, InterfacePort port):
 	partDP.name + "_" + port.name;
@@ -933,12 +1015,14 @@ cached boolean portGeneratesFragment(PortType type) :
 /*
  * Create an AMI4CCM_Connector implementation.
  */
-create MonolithicDeploymentDescription createConnectorImplementation(CORBAInterface intf, String portConnectorType, DeploymentPlan deployment) :
+create MonolithicDeploymentDescription findOrCreateInterfacePortConnector(CORBAInterface intf, ConnectorDef connectorType, CCM::CCM_Deployment::DeploymentPlan deployment) :
+    let plan = findOrCreateDeploymentPlan(deployment):
 	let artifact = {}:
 	let modifiedInterfaceName = {}:
 	let componentFactoryParameter = {}:
 	let servantEntryPointParameter = {}:
 	let artifactRef = {}:
+    let portConnectorType = connectorType.name:
 	let name = getConnectorName(intf, portConnectorType):
 	let executorArtifactParameter = {}:
 	let servantArtifactParameter = {}:
@@ -958,7 +1042,7 @@ create MonolithicDeploymentDescription createConnectorImplementation(CORBAInterf
 	executorArtifactParameter.add(intf.createProperty("EXEC_ARTIFACT", "", artifact.first().name.first(), "")) ->
 	servantArtifactParameter.add(intf.createProperty("SVNT_ARTIFACT", "", artifact.first().name.first(), "")) ->
 	//	
-	deployment.artifact.add(artifact.first()) ->
+	plan.artifact.add(artifact.first()) ->
 	this.name.add(name) ->
 	this.artifact.add(artifactRef.first()) ->
 	this.execParameter.add(componentFactoryParameter.first())->
@@ -966,10 +1050,10 @@ create MonolithicDeploymentDescription createConnectorImplementation(CORBAInterf
 	this.execParameter.add(servantEntryPointParameter.first())->
 	this.execParameter.add(servantArtifactParameter.first())->
 	this.JavaSetAttribute("id", getUUID()) ->	
-	deployment.implementation.add(this);
+	plan.implementation.add(this);
 
-Void visitPortType(InterfacePort ip, DeploymentPlan plan) :
-    createConnectorImplementation(ip.porttype, ip.connectorType.name, plan);
+Void visitPortType(InterfacePort ip, CCM::CCM_Deployment::DeploymentPlan deployment) :
+    findOrCreateInterfacePortConnector(ip.porttype, ip.connectorType, deployment);
     	
 cached boolean isUsedSynchronously(CORBAInterface self) :
 	JAVA com.zeligsoft.domain.dds4ccm.utils.DDS4CCMUtil.isUsedSynchronously(
@@ -1001,7 +1085,7 @@ cached boolean isUsedAsynchronously(InterfacePort port) :
 	}} ->
 	isNonLocalAsync.first();	
 	
-Void visitPortType(PortType o, DeploymentPlan plan) :
+Void visitPortType(PortType o, CCM::CCM_Deployment::DeploymentPlan deployment) :
 	{};
 
 /*
@@ -1362,7 +1446,7 @@ create InstanceDeploymentDescription createContainerProcessInstance(DeploymentPa
    	    // if this property does not exist then create a default one
     	this.createProcessNameProperty(process)
 	};
-
+	
 create Property createProcessNameProperty(InstanceDeploymentDescription instance, DeploymentPart process ) :
 	this.name.add(getModelTypeSpecificProperty("LM_PROCESSNAME")) ->
 	this.value.add(this.createProcessNamePropertyValue(process)) ->

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/category.xml
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/category.xml
@@ -54,6 +54,10 @@
    <feature url="features/org.eclipse.xtend.typesystem.xsd_2.2.0.v201605260315.jar" id="org.eclipse.xtend.typesystem.xsd" version="2.2.0.v201605260315">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
+   <!-- org.eclipse.xtend.sdk.feature.group 2.18.0.v20190528-0716 -->
+   <feature url="features/org.eclipse.xtend.sdk_2.18.0.v20190528-0716.jar" id="org.eclipse.xtend.sdk" version="2.18.0.v20190528-0716">
+      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   </feature>
    <feature url="features/com.zeligsoft.domain.ngc.ccm.axcioma_feature_4.0.0.qualifier.jar" id="com.zeligsoft.domain.ngc.ccm.axcioma_feature" version="4.0.0.qualifier">
       <category name="com.zeligsoft.dds4ccmmaster.category"/>
    </feature>
@@ -76,6 +80,26 @@
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
    <bundle id="org.eclipse.xtend.typesystem.emf" version="2.2.0.v201605260315">
+      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   </bundle>
+   <!-- org.freemarker org.freemarker_2.3.22.v20160210-1233.jar -->
+   <bundle id="org.freemarker" version="2.3.22.v20160210-1233">
+      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   </bundle>
+   <!-- org.eclipse.tools.templates.freemarker -->
+   <bundle id="org.eclipse.tools.templates.freemarker" version="1.0.0.201812111206">
+      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   </bundle>
+   <!-- org.eclipse.tools.templates.core -->
+   <bundle id="org.eclipse.tools.templates.core" version="1.1.0.201812111206">
+      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   </bundle>
+   <!-- javax.xml.stream -->
+   <bundle id="javax.xml.stream" version="1.0.1.v201004272200">
+      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   </bundle>
+   <!-- com.sun.xml.bind -->
+   <bundle id="com.sun.xml.bind" version="2.2.0.v201505121915">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </bundle>
    <category-def name="com.zelgisoft.dds4ccm.cdt.category" label="CDT">

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
@@ -5,7 +5,7 @@
 #===============================================================================
 
 %define ifdef()   %if %{expand:%%{?%{1}:1}%%{!?%{1}:0}}
-%define ver       1.6.1
+%define ver       2.0.0
 %define rel       0.%(date "+%y%m%d%H%M")
 %define _rpmdir   %{_projectdir}/rpm_build/
 %define _targetdir %{_projectdir}/target
@@ -46,15 +46,15 @@ cp %{_targetdir}/dds4ccm_*.v*.zip %{buildroot}/opt/cx-axcioma/
 # Define RPM scripts (%%pre and %%post sections)
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 %pre
-axciomaInstalledFeature=$(/opt/IBM/SDP/eclipse -application org.eclipse.equinox.p2.director -listInstalledRoots -nosplash | grep com.zeligsoft.domain.ngc.ccm.axcioma_feature.feature.group)
-atcdInstalledFeature=$(/opt/IBM/SDP/eclipse -application org.eclipse.equinox.p2.director -listInstalledRoots -nosplash | grep com.zeligsoft.domain.ngc.ccm_feature.feature.group)
+axciomaInstalledFeature=$(/opt/Papyrus/eclipse -application org.eclipse.equinox.p2.director -listInstalledRoots -nosplash | grep com.zeligsoft.domain.ngc.ccm.axcioma_feature.feature.group)
+atcdInstalledFeature=$(/opt/Papyrus/eclipse -application org.eclipse.equinox.p2.director -listInstalledRoots -nosplash | grep com.zeligsoft.domain.ngc.ccm_feature.feature.group)
 
 if [[ ${axciomaInstalledFeature} != "" ]]; then 		# axcioma is already installed
-/opt/IBM/SDP/eclipse \
+/opt/Papyrus/eclipse \
    -application org.eclipse.equinox.p2.director \
    -nosplash \
-   -uninstallIU com.zeligsoft.base.feature.group  \
-   -uninstallIU com.zeligsoft.cx.feature.group  \
+   -uninstallIU com.zeligsoft.base_feature.feature.group  \
+   -uninstallIU com.zeligsoft.cx_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.idl3plus_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.ngc.ccm.axcioma_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.omg.ccm_feature.feature.group \
@@ -65,11 +65,11 @@ if [[ ${axciomaInstalledFeature} != "" ]]; then 		# axcioma is already installed
    -XX:PermSize=256M \
    -XX:MaxPermSize=512M
 elif [[ ${atcdInstalledFeature} != "" ]]; then 		# atcd is already installed
-/opt/IBM/SDP/eclipse \
+/opt/Papyrus/eclipse \
    -application org.eclipse.equinox.p2.director \
    -nosplash \
-   -uninstallIU com.zeligsoft.base.feature.group  \
-   -uninstallIU com.zeligsoft.cx.feature.group  \
+   -uninstallIU com.zeligsoft.base_feature.feature.group  \
+   -uninstallIU com.zeligsoft.cx_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.idl3plus_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.ngc.ccm_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.omg.ccm_feature.feature.group \
@@ -84,24 +84,24 @@ fi
 %post
 # Get timestamp of CX zip file
 timestamp=$(echo /opt/cx-axcioma/*.zip | sed -rn 's/.*\.v([0-9]*)\.zip/\1/p')
-/opt/IBM/SDP/eclipse \
+/opt/Papyrus/eclipse \
    -application org.eclipse.equinox.p2.director \
    -nosplash \
    -repository \
    jar:file:/opt/cx-axcioma/dds4ccm_axcioma_%{ver}.v${timestamp}.zip\!/ \
-   -installIU com.zeligsoft.base.feature.group  \
-   -installIU com.zeligsoft.cx.feature.group  \
+   -installIU com.zeligsoft.base_feature.feature.group  \
+   -installIU com.zeligsoft.cx_feature.feature.group  \
    -installIU com.zeligsoft.domain.idl3plus_feature.feature.group  \
    -installIU com.zeligsoft.domain.ngc.ccm.axcioma_feature.feature.group  \
    -installIU com.zeligsoft.domain.omg.ccm_feature.feature.group
 
 %postun
 if [ $1 == 0 ] ; then					# this is an uninstallation, not an upgrade
-/opt/IBM/SDP/eclipse \
+/opt/Papyrus/eclipse \
    -application org.eclipse.equinox.p2.director \
    -nosplash \
-   -uninstallIU com.zeligsoft.base.feature.group  \
-   -uninstallIU com.zeligsoft.cx.feature.group  \
+   -uninstallIU com.zeligsoft.base_feature.feature.group  \
+   -uninstallIU com.zeligsoft.cx_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.idl3plus_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.ngc.ccm.axcioma_feature.feature.group  \
    -uninstallIU com.zeligsoft.domain.omg.ccm_feature.feature.group \


### PR DESCRIPTION
CPD generation. Merges the following to papyrus branch: #70, #71 and #72 

Closes #73 

RPM now references correct IUs, version 2.0.0, and /opt/Papyrus. Update site includes missing plug-ins & features.

Closes #75 

Papyrus build now only builds an AXCIOMA update site and RPM. Note that this update site still allows for ATCD modelling.