### PR TITLE
Correctly install RPM against Papyrus RCP app

### DIFF
--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/category.xml
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/category.xml
@@ -58,6 +58,10 @@
    <feature url="features/org.eclipse.xtend.sdk_2.18.0.v20190528-0716.jar" id="org.eclipse.xtend.sdk" version="2.18.0.v20190528-0716">
       <category name="com.zelgisoft.dds4ccm.deps.category"/>
    </feature>
+   <!-- org.eclipse.xtext.xbase.feature.group 2.18.0.v20190528-0716 -->
+   <feature url="features/org.eclipse.xtext.xbase_2.18.0.v20190528-0716.jar" id="org.eclipse.xtext.xbase" version="2.18.0.v20190528-0716">
+      <category name="com.zelgisoft.dds4ccm.deps.category"/>
+   </feature>
    <feature url="features/com.zeligsoft.domain.ngc.ccm.axcioma_feature_4.0.0.qualifier.jar" id="com.zeligsoft.domain.ngc.ccm.axcioma_feature" version="4.0.0.qualifier">
       <category name="com.zeligsoft.dds4ccmmaster.category"/>
    </feature>

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
@@ -46,11 +46,11 @@ cp %{_targetdir}/dds4ccm_*.v*.zip %{buildroot}/opt/cx-axcioma/
 # Define RPM scripts (%%pre and %%post sections)
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 %pre
-axciomaInstalledFeature=$(/opt/Papyrus/eclipse -application org.eclipse.equinox.p2.director -listInstalledRoots -nosplash | grep com.zeligsoft.domain.ngc.ccm.axcioma_feature.feature.group)
-atcdInstalledFeature=$(/opt/Papyrus/eclipse -application org.eclipse.equinox.p2.director -listInstalledRoots -nosplash | grep com.zeligsoft.domain.ngc.ccm_feature.feature.group)
+axciomaInstalledFeature=$(/opt/Papyrus/papyrus -application org.eclipse.equinox.p2.director -listInstalledRoots -nosplash | grep com.zeligsoft.domain.ngc.ccm.axcioma_feature.feature.group)
+atcdInstalledFeature=$(/opt/Papyrus/papyrus -application org.eclipse.equinox.p2.director -listInstalledRoots -nosplash | grep com.zeligsoft.domain.ngc.ccm_feature.feature.group)
 
 if [[ ${axciomaInstalledFeature} != "" ]]; then 		# axcioma is already installed
-/opt/Papyrus/eclipse \
+/opt/Papyrus/papyrus \
    -application org.eclipse.equinox.p2.director \
    -nosplash \
    -uninstallIU com.zeligsoft.base_feature.feature.group  \
@@ -65,7 +65,7 @@ if [[ ${axciomaInstalledFeature} != "" ]]; then 		# axcioma is already installed
    -XX:PermSize=256M \
    -XX:MaxPermSize=512M
 elif [[ ${atcdInstalledFeature} != "" ]]; then 		# atcd is already installed
-/opt/Papyrus/eclipse \
+/opt/Papyrus/papyrus \
    -application org.eclipse.equinox.p2.director \
    -nosplash \
    -uninstallIU com.zeligsoft.base_feature.feature.group  \
@@ -84,7 +84,7 @@ fi
 %post
 # Get timestamp of CX zip file
 timestamp=$(echo /opt/cx-axcioma/*.zip | sed -rn 's/.*\.v([0-9]*)\.zip/\1/p')
-/opt/Papyrus/eclipse \
+/opt/Papyrus/papyrus \
    -application org.eclipse.equinox.p2.director \
    -nosplash \
    -repository \
@@ -97,7 +97,7 @@ timestamp=$(echo /opt/cx-axcioma/*.zip | sed -rn 's/.*\.v([0-9]*)\.zip/\1/p')
 
 %postun
 if [ $1 == 0 ] ; then					# this is an uninstallation, not an upgrade
-/opt/Papyrus/eclipse \
+/opt/Papyrus/papyrus \
    -application org.eclipse.equinox.p2.director \
    -nosplash \
    -uninstallIU com.zeligsoft.base_feature.feature.group  \


### PR DESCRIPTION
- added org.eclipse.xtext.xbase as a dependency
- corrected RPM to use /opt/Papyrus/papyrus as the eclipse target and executable.

Signed-off-by: Paul Elder <11318425+elder4p@users.noreply.github.com>