### PR TITLE
Issue 132: NPEs popup in Model Differences view

### DIFF
--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
@@ -564,6 +564,13 @@
             strategy="com.zeligsoft.domain.dds4ccm.ui.paste.DDS4CCMPasteStrategy">
       </strategy>
    </extension>
+   <extension
+         point="org.eclipse.papyrus.infra.services.labelprovider.labelProvider">
+      <labelProvider
+            priority="10"
+            provider="com.zeligsoft.domain.dds4ccm.ui.providers.ResolvingUMLFilteredLabelProvider">
+      </labelProvider>
+   </extension>
    
     <!--
    <extension

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/providers/ResolvingUMLFilteredLabelProvider.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/providers/ResolvingUMLFilteredLabelProvider.java
@@ -1,0 +1,66 @@
+/**
+ * 
+ */
+package com.zeligsoft.domain.dds4ccm.ui.providers;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.papyrus.uml.tools.providers.UMLFilteredLabelProvider;
+import org.eclipse.swt.graphics.Image;
+
+import com.zeligsoft.base.Activator;
+
+/**
+ * @author eposse
+ */
+public class ResolvingUMLFilteredLabelProvider extends UMLFilteredLabelProvider {
+	
+	@Override
+	public boolean accept(Object element) {
+		if (element instanceof EObject) {
+			EObject eObject = (EObject)element;
+			eObject = resolveProxy(eObject);
+			return super.accept(eObject);
+		}
+		return super.accept(element);
+	}
+
+	@Override
+	public Image getImage(Object element) {
+		if (element instanceof EObject) {
+			EObject eObject = (EObject)element;
+			eObject = resolveProxy(eObject);
+			return super.getImage(eObject);
+		}
+		return super.getImage(element);
+	}
+
+	/**
+	 * @param eObject - An {@link EObject}
+	 * @return The resolved {@link EObject} is the given one is a proxy, or the given eObject itself otherwise.
+	 */
+	protected EObject resolveProxy(EObject eObject) {
+		if (eObject.eIsProxy()) {
+			Resource eClassResource = eObject.eClass().eResource();
+//			if (eClassResource != null) {
+//				ResourceSet eClassResourceSet = eClassResource.getResourceSet();
+//				if (eClassResourceSet != null) {
+//					URI proxyURI = ((InternalEObject)eObject).eProxyURI();
+//					URI normalizedURI = eClassResourceSet.getURIConverter().normalize(proxyURI);
+//					Resource eObjectResource = eClassResourceSet.getResource(normalizedURI, true);
+//					ResourceSet eObjectResourceSet = eObjectResource.getResourceSet();
+//					if (eObjectResourceSet != eClassResourceSet) {
+//						Activator.getDefault().warning("Proxy resource set is not the same as it's eClass'");
+//					}
+//				}
+//			}
+			eObject = EcoreUtil.resolve(eObject, eClassResource);
+		}
+		return eObject;
+	}
+
+}

--- a/bundles/com.zeligsoft.domain.dds4ccm/META-INF/MANIFEST.MF
+++ b/bundles/com.zeligsoft.domain.dds4ccm/META-INF/MANIFEST.MF
@@ -23,7 +23,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.113.0",
  com.zeligsoft.domain.zml.api;bundle-version="3.5.0",
  com.zeligsoft.domain.omg.corba.api;bundle-version="3.5.0",
  com.zeligsoft.domain.idl3plus.api;bundle-version="3.5.0",
- org.eclipse.papyrus.uml.extensionpoints;bundle-version="1.3.0"
+ org.eclipse.papyrus.uml.extensionpoints;bundle-version="1.3.0",
+ org.eclipse.uml2.uml.edit;bundle-version="5.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: com.zeligsoft.domain.dds4ccm,

--- a/bundles/com.zeligsoft.domain.dds4ccm/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm/plugin.xml
@@ -61,6 +61,14 @@
             name="cxDDS4CCM"
             path="pathmap://DDS4CCM_PROFILES/dds4ccm.profile.uml">
       </profile>
+   </extension>
+   <extension
+         point="org.eclipse.emf.edit.itemProviderAdapterFactories">
+      <factory
+            class="org.eclipse.uml2.uml.edit.providers.UMLItemProviderAdapterFactory"
+            supportedTypes="org.eclipse.emf.edit.provider.IItemLabelProvider"
+            uri="http://www.zeligsoft.com/domain/dds4ccm/2010/DDS4CCM/1">
+      </factory>
    </extension>   
    
 </plugin>


### PR DESCRIPTION
Added a label provider which resolves EObject proxies and delegates to
the UMLFilteredLabelProvider who knows how to deal with UML models
including stereotypes.


Signed-off-by: Ernesto Posse <eposse@zeligsoft.com>