### PR TITLE
Issue #150: Log entry introduced for org.eclipse.papyrus.infra.ui.editor.IMultiDiagramEditor

### DIFF
--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/plugin.xml
@@ -563,7 +563,7 @@
       <service
             classname="com.zeligsoft.domain.dds4ccm.ui.services.CoreMultiDiagramEditorService"
             id="org.eclipse.papyrus.infra.ui.editor.IMultiDiagramEditor"
-            priority="Integer.MAX_VALUE"
+            priority="-1"
             startKind="startup">
       </service>
       <service


### PR DESCRIPTION
By ensuring that the new service has lower priority than the service provided by Papyrus, the later will be registered over the former when opening a Papyrus Model.

The new service will only be registered in the context of a Diff/Merge with Papyrus Compare.

Signed-off-by: Ernesto Posse <eposse@zeligsoft.com>