### PR TITLE
Issue #63: GIS Templated Connectors cannot be typed with a Struct, only

### DIFF
--- a/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/xtend/includes.ext
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/xtend/includes.ext
@@ -243,7 +243,7 @@ Void processIncludes(DDSMessage self, idl::Specification spec) :
 	self.fields.idlType.addIncludesFor(spec);
 	
 Void processDefnIncludes(ModuleInstantiation self, idl::Specification spec) :
-	self.moduleBinding.parameterBinding.type.typeSelect(DDSMessage).addIncludesFor(spec);	
+	self.moduleBinding.parameterBinding.type.typeSelect(CXStruct).addIncludesFor(spec);	
 	
 private cached Void addIncludesFor(CXModuleContained element, idl::Specification spec) :
 	addIncludesFor(element.eContainer, spec);


### PR DESCRIPTION
DDS message