### PR TITLE
Issue #249: Accidental dragging of assemblies into themselves does not

### DIFF
--- a/bundles/com.zeligsoft.domain.zml/src/com/zeligsoft/domain/zml/util/ZDeploymentUtil.java
+++ b/bundles/com.zeligsoft.domain.zml/src/com/zeligsoft/domain/zml/util/ZDeploymentUtil.java
@@ -604,6 +604,10 @@ public class ZDeploymentUtil {
 
 		Component deployment = (Component) parentPart.getOwner();
 
+		if(parentPart.getType() == component) {
+			// assembly cannot contain itself.
+			return;
+		}
 		// The list of parts from which to create substructure will
 		// vary depending on whether we are working with a
 		// <<ComponentInterface>>


### PR DESCRIPTION
always spawn an error dialog