### PR TITLE
Issue #295: Add 'Absorb Merged Packages' to 'ZDL Tools' popup

### DIFF
--- a/ddk/com.zeligsoft.ddk.tools/OSGI-INF/l10n/bundle.properties
+++ b/ddk/com.zeligsoft.ddk.tools/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 Northrop Grumman Systems Corporation.
+# Copyright (c) 2020, 2021 Northrop Grumman Systems Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,3 +20,10 @@ action.label = Export to UML
 Bundle-Vendor = Zeligsoft (2009) Ltd.
 Bundle-Name = Zeligsoft DDK Tools UI
 page.name.0 = URI Mappings
+tools.category.description = DDK Tools
+tools.category.name = DDK Tools
+absorb.command.description = Combine all models referenced by a 'PackageMerge' into a single model.
+absorb.command.name = Absorb Merged Packages
+tools.menu.label = DDK Tools
+tools.menu.absorb.label = Absorb Merged Packages
+tools.memu.absorb.mnemonic = A

--- a/ddk/com.zeligsoft.ddk.tools/plugin.xml
+++ b/ddk/com.zeligsoft.ddk.tools/plugin.xml
@@ -41,5 +41,58 @@
             name="%page.name.0">
       </page>
    </extension>
+   <extension
+         point="org.eclipse.ui.commands">
+      <category
+            description="%tools.category.description"
+            id="com.zeligsoft.ddk.tools"
+            name="%tools.category.name">
+      </category>
+      <command
+            categoryId="com.zeligsoft.ddk.tools"
+            defaultHandler="com.zeligsoft.ddk.tools.ui.internal.handlers.AbsorbMergedPackagesHandler"
+            description="%absorb.command.description"
+            id="com.zeligsoft.ddk.tools.absortMergedModels"
+            name="%absorb.command.name">
+      </command>
+   </extension>
+   <extension
+         point="org.eclipse.ui.menus">
+      <menuContribution
+            allPopups="false"
+            locationURI="popup:org.eclipse.ui.popup.any">
+         <menu
+               label="%tools.menu.label">
+            <command
+                  commandId="com.zeligsoft.ddk.tools.absortMergedModels"
+                  label="%tools.menu.absorb.label"
+                  mnemonic="%tools.memu.absorb.mnemonic"
+                  style="push">
+               <visibleWhen
+                     checkEnabled="false">
+                  <with
+                        variable="selection">
+                     <and>
+                        <count
+                              value="1">
+                        </count>
+                        <iterate
+                              ifEmpty="false"
+                              operator="or">
+                           <adapt
+                                 type="org.eclipse.core.resources.IFile">
+                              <test
+                                    property="org.eclipse.core.resources.name"
+                                    value="*.uml">
+                              </test>
+                           </adapt>
+                        </iterate>
+                     </and>
+                  </with>
+               </visibleWhen>
+            </command>
+         </menu>
+      </menuContribution>
+   </extension>
 
 </plugin>

--- a/ddk/com.zeligsoft.ddk.tools/src/com/zeligsoft/ddk/tools/ui/internal/handlers/AbsorbMergedPackagesHandler.java
+++ b/ddk/com.zeligsoft.ddk.tools/src/com/zeligsoft/ddk/tools/ui/internal/handlers/AbsorbMergedPackagesHandler.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Northrop Grumman Systems Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.zeligsoft.ddk.tools.ui.internal.handlers;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.osgi.framework.Bundle;
+
+/**
+ * Default command handler to Absorb PackageMerge elements directly into the referencing model.
+ * For an input xxx.uml, produces an output xxx.merged.uml.
+ *
+ */
+public class AbsorbMergedPackagesHandler extends AbstractHandler implements IHandler {
+
+	private void logError(CoreException e) {
+	    Bundle bundle = Platform.getBundle(com.zeligsoft.ddk.tools.Activator.PLUGIN_ID);
+	    ILog log = Platform.getLog(bundle);
+	    log.log(e.getStatus());
+	}
+	
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		final ISelection selection = HandlerUtil.getCurrentSelectionChecked(event);
+		
+		try {
+			return new AbsorbMergedPackagesWorker(selection).doWork();
+		} catch(CoreException e) {
+			final IWorkbenchWindow window = HandlerUtil.getActiveWorkbenchWindowChecked(event);
+			if(e.getStatus().getSeverity() == IStatus.ERROR) {
+				MessageDialog.openError(
+						window.getShell(),
+						Messages.AbsorbMergedPackagesHandler_DialogTitle,
+						e.getStatus().getMessage());
+				logError(e);
+			} else if(e.getStatus().getSeverity() == IStatus.WARNING) {
+				MessageDialog.openWarning(
+						window.getShell(),
+						Messages.AbsorbMergedPackagesHandler_DialogTitle,
+						e.getStatus().getMessage());
+			}
+			return null;
+		}
+	}
+
+}

--- a/ddk/com.zeligsoft.ddk.tools/src/com/zeligsoft/ddk/tools/ui/internal/handlers/AbsorbMergedPackagesWorker.java
+++ b/ddk/com.zeligsoft.ddk.tools/src/com/zeligsoft/ddk/tools/ui/internal/handlers/AbsorbMergedPackagesWorker.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Northrop Grumman Systems Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.zeligsoft.ddk.tools.ui.internal.handlers;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.uml2.uml.util.UMLUtil;
+
+/**
+ * Worker class that performs the merging of MergePackage elements into the referencing model.
+ * This calls is separate from the core command handler/action handler to enable reuse in a
+ * variety of Eclipse menu/command environments that have existed of the past decade.
+ *
+ */
+public class AbsorbMergedPackagesWorker {
+	
+	/**
+	 * Exception thrown if selection is not conform to expectations
+	 *
+	 */
+	private static class IllegalSelectionException extends Exception {
+
+		/**
+		 * 
+		 */
+		private static final long serialVersionUID = 1L;
+		
+		public IllegalSelectionException(String message) {
+			super(message + " " + Messages.AbsorbMergedPackagesWorker_SelectionRequirements); //$NON-NLS-1$
+		}
+		
+	}
+	
+	/**
+	 * Exception thrown if there is nothing to merge.
+	 */
+	private static class NoPackageMergeElementsException extends Exception {
+
+		/**
+		 * 
+		 */
+		private static final long serialVersionUID = 1L;
+		
+		public NoPackageMergeElementsException(String message) {
+			super(message);
+		}
+		
+	}
+	
+	private final ISelection selection;
+
+	public AbsorbMergedPackagesWorker(final ISelection selection) {
+		this.selection = selection;
+		
+	}
+
+	private void raiseCoreExceptionError(Throwable ex) throws CoreException {
+		throw new CoreException(new Status(IStatus.ERROR, com.zeligsoft.ddk.tools.Activator.PLUGIN_ID,
+				ex.getMessage(), ex));
+	}
+	
+	private void raiseCoreExceptionWarning(Throwable ex) throws CoreException {
+		throw new CoreException(new Status(IStatus.WARNING, com.zeligsoft.ddk.tools.Activator.PLUGIN_ID,
+				ex.getMessage(), ex));
+	}
+	
+	public IPath doWork() throws CoreException {
+		try {
+			// sanity check the exception. The menu configuration should prevent most of these, but...
+			if(!(selection instanceof IStructuredSelection)) {
+				throw new IllegalSelectionException(Messages.AbsorbMergedPackagesWorker_NotIStructureSelection);
+			}
+			final IStructuredSelection ss = (IStructuredSelection)selection;
+			if(ss.size() != 1) {
+				throw new IllegalSelectionException(Messages.AbsorbMergedPackagesWorker_NotSize1Selection);
+			}
+			
+			final Object sel = ss.getFirstElement();
+			if(!(sel instanceof IFile)) {
+				throw new IllegalSelectionException(Messages.AbsorbMergedPackagesWorker_SelectionNotAFile);
+			}
+			final IFile file = (IFile)sel;
+			if(!(file.getFileExtension().equals("uml"))) { //$NON-NLS-1$
+				throw new IllegalSelectionException(Messages.AbsorbMergedPackagesWorker_SelectionNotUmlFile);
+			}
+			
+			// derive the new file from the existing files name.
+			final IFile newFile = file.getParent().getFile(new Path(file.getName().replace(".uml", ".merged.uml"))); //$NON-NLS-1$ //$NON-NLS-2$
+			
+			// load the existing model
+			final ResourceSet rset = new ResourceSetImpl();
+			final URI fileURI = URI.createURI("platform:/resource/" + file.getFullPath().toString()); //$NON-NLS-1$
+			Resource res = rset.getResource(fileURI, true);
+			final EObject rootObj = res.getContents().get(0);
+			if(!(rootObj instanceof org.eclipse.uml2.uml.Package)) {
+				throw new IllegalSelectionException(Messages.AbsorbMergedPackagesWorker_RootElementNotPackage);
+			}
+			
+			// merge any/all PackageMerge Elements
+			final org.eclipse.uml2.uml.Package rootPkg = (org.eclipse.uml2.uml.Package)rootObj;
+			Map<String, String> options = new HashMap<>();
+			final Map<EObject, List<EObject>> merges = UMLUtil.merge(rootPkg, options);
+			
+			if(merges.size() == 0) {
+				throw new NoPackageMergeElementsException(Messages.AbsorbMergedPackagesWorker_NoPackageMergesFound);
+			}
+		
+			// save the modified model to the new path
+			res.setURI(URI.createURI("platform:/resource/" + newFile.getFullPath().toString())); //$NON-NLS-1$
+			
+			res.save(null);
+			return newFile.getFullPath();
+			
+		} catch (IOException e) {
+			raiseCoreExceptionError(e);
+		} catch (NoPackageMergeElementsException e) {
+			raiseCoreExceptionWarning(e);
+		} catch (IllegalSelectionException e) {
+			raiseCoreExceptionError(e);
+		}
+		return null;
+	}
+}

--- a/ddk/com.zeligsoft.ddk.tools/src/com/zeligsoft/ddk/tools/ui/internal/handlers/Messages.java
+++ b/ddk/com.zeligsoft.ddk.tools/src/com/zeligsoft/ddk/tools/ui/internal/handlers/Messages.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Northrop Grumman Systems Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package com.zeligsoft.ddk.tools.ui.internal.handlers;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+	private static final String BUNDLE_NAME = "com.zeligsoft.ddk.tools.ui.internal.handlers.messages"; //$NON-NLS-1$
+	public static String AbsorbMergedPackagesHandler_DialogTitle;
+	public static String AbsorbMergedPackagesWorker_NoPackageMergesFound;
+	public static String AbsorbMergedPackagesWorker_NotIStructureSelection;
+	public static String AbsorbMergedPackagesWorker_NotSize1Selection;
+	public static String AbsorbMergedPackagesWorker_RootElementNotPackage;
+	public static String AbsorbMergedPackagesWorker_SelectionNotAFile;
+	public static String AbsorbMergedPackagesWorker_SelectionNotUmlFile;
+	public static String AbsorbMergedPackagesWorker_SelectionRequirements;
+	static {
+		// initialize resource bundle
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	private Messages() {
+	}
+}

--- a/ddk/com.zeligsoft.ddk.tools/src/com/zeligsoft/ddk/tools/ui/internal/handlers/messages.properties
+++ b/ddk/com.zeligsoft.ddk.tools/src/com/zeligsoft/ddk/tools/ui/internal/handlers/messages.properties
@@ -1,0 +1,23 @@
+###############################################################################
+# Copyright (c) 2021 Northrop Grumman Systems Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+AbsorbMergedPackagesHandler_DialogTitle=Absorb Merged Packages
+AbsorbMergedPackagesWorker_NoPackageMergesFound=No PackageMerge elements found. Merged model is not required and was not created.
+AbsorbMergedPackagesWorker_NotIStructureSelection=Selection is not an IStructuredSelection.
+AbsorbMergedPackagesWorker_NotSize1Selection=Selection is not of size 1.
+AbsorbMergedPackagesWorker_RootElementNotPackage=Root object of model is not a uml Package.
+AbsorbMergedPackagesWorker_SelectionNotAFile=Selection is not a file.
+AbsorbMergedPackagesWorker_SelectionNotUmlFile=Selection is not a .uml file.
+AbsorbMergedPackagesWorker_SelectionRequirements=Selection must be a single .uml file with a Package or Model element at its root.


### PR DESCRIPTION
- new eclipse command
- new command handler implementation
- new eclipse menu contribution
- most business logic is in AbsorbMergedPackagesWorker.java
- separate worker allows for re-use in older Eclipse 'action sets'