### PR TITLE
Issue #303: Fix import issue with Union

### DIFF
--- a/bundles/com.zeligsoft.domain.dds4ccm.idlimport/template/ddsIdl3Import.ext
+++ b/bundles/com.zeligsoft.domain.dds4ccm.idlimport/template/ddsIdl3Import.ext
@@ -15,7 +15,6 @@
  *
  */
 
-import CXDomain::IDLFileSupport; // needed for IDLFile and similar
 import CXDomain::IDL; // needed for CXModule etc.
 import ZMLMM::ZML_Component;
 import ZMLMM::ZML_Core;

--- a/bundles/com.zeligsoft.domain.dds4ccm.idlimport/template/importOrganizer.ext
+++ b/bundles/com.zeligsoft.domain.dds4ccm.idlimport/template/importOrganizer.ext
@@ -95,12 +95,7 @@ Void organize(StructType def ) :
 	addElementToPackage(def.name);
 	
 Void organize(UnionType def ) :
-	{};
-	
-/* Need to fix union-importing into a top level model or else this throws an exception.
-Void organize(UnionType def ) :
 	addElementToPackage(def.name);
-*/
 	
 Void organize(TypeDeclarator def ) :
 	addElementToPackage(def.declarators.first().id);

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/l10n/Messages.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui/src/com/zeligsoft/domain/dds4ccm/ui/l10n/Messages.properties
@@ -103,7 +103,6 @@ ShowSourceActionDelegate_3=Project does not exist
 
 ToggleNature_Error = Error occurred trying to toggle project nature.
 
-MigrationChecker_OpenedPapyrusEditor=Opened Papyrus multi-diagram editor
 MigrationChecker_MigrationRequired=Model migration is required for model ''{0}''. Do you want to migrate the model now?
 MigrationChecker_MigrationRequired_DialogTitle=Model migration required
 MigrationChecker_MigrationConfirmed=Model migration confirmed

--- a/bundles/com.zeligsoft.domain.omg.ccm.idlimport/template/idl3Import.ext
+++ b/bundles/com.zeligsoft.domain.omg.ccm.idlimport/template/idl3Import.ext
@@ -1,4 +1,3 @@
-import CXDomain::IDLFileSupport; // needed for IDLFile and similar
 import CXDomain::IDL; // needed for CXModule etc.
 import ZMLMM::ZML_Component;
 import ZMLMM::ZML_Core;
@@ -30,12 +29,6 @@ Void resolveUnresolvedIdl3Lookups() :
 Void addIdl3Scope() :
 	JAVA com.zeligsoft.domain.omg.ccm.idlimport.IDL3ImportUtils.addIdl3Scope();
 
-Void visitContained(File_Marker file, uml::Package package ) :
-	{};
-	
-Void visitContained(Excluded_File_Marker file, uml::Package package ) :
-	{};
-	
 Void visitContained(Definition o, uml::Package container) :
 	{};
 	
@@ -279,15 +272,9 @@ create CXInterface visitContained(Interface_decl intf, uml::Package container) :
 	container.packagedElement.add(this) ->
 	this.configureInterface(intf);
 	
-create CXConstant visitContained(ConstDecl const, uml::Package file) :
-	file.addConstant(this) ->
-	this.setName(const.name) ->
-	this.setTypedElementType(const.type) ->
-	this.setDefault(const.value.getConstValue());
-	
-create uml::DataType visitContained(TypeDeclarator typedef, uml::Package file) :
+create uml::DataType visitContained(TypeDeclarator typedef, uml::Package package) :
 	// could be a typedef, a sequence, or an array.
-	file.packagedElement.add(this) ->
+	package.packagedElement.add(this) ->
 	this.setName(typedef.declarators.get(0).id) ->	
 	this.applyTypedefConcept(typedef);	
 	

--- a/bundles/com.zeligsoft.domain.omg.corba.idlimport/src/com/zeligsoft/domain/omg/corba/idlimport/IDLPreprocessor.java
+++ b/bundles/com.zeligsoft.domain.omg.corba.idlimport/src/com/zeligsoft/domain/omg/corba/idlimport/IDLPreprocessor.java
@@ -53,7 +53,7 @@ public class IDLPreprocessor extends AbstractWorkflowComponent {
 
 	private final String INCLUDE_MARKER_OPTION = " --includemarker \"#file \\\"%:%:%\\\"\" "; //$NON-NLS-1$
 
-	private final String USER_NAME = System.getProperty("user.name").replaceAll(" ", ""); //$NON-NLS-1$
+	private final String USER_NAME = System.getProperty("user.name").replaceAll(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	
 	private final String TEMP_IDL_FILENAME = USER_NAME + "_tmp.idl"; //$NON-NLS-1$
 

--- a/bundles/com.zeligsoft.domain.omg.corba.idlimport/src/com/zeligsoft/domain/omg/corba/idlimport/XtendUtils.java
+++ b/bundles/com.zeligsoft.domain.omg.corba.idlimport/src/com/zeligsoft/domain/omg/corba/idlimport/XtendUtils.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2018 ADLINK Technology Limited.
+/*******************************************************************************
+ * Copyright (c) 2021 Northrop Grumman Systems Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- */
+ *******************************************************************************/
+
 package com.zeligsoft.domain.omg.corba.idlimport;
 
 
@@ -58,8 +58,6 @@ import com.zeligsoft.domain.omg.corba.dsl.idl.ConstExp;
 import com.zeligsoft.domain.omg.corba.dsl.idl.ElementSpec;
 import com.zeligsoft.domain.omg.corba.dsl.idl.EnumType;
 import com.zeligsoft.domain.omg.corba.dsl.idl.ExceptionList;
-import com.zeligsoft.domain.omg.corba.dsl.idl.Excluded_File_Marker;
-import com.zeligsoft.domain.omg.corba.dsl.idl.File_Marker;
 import com.zeligsoft.domain.omg.corba.dsl.idl.Interface_decl;
 import com.zeligsoft.domain.omg.corba.dsl.idl.Literal;
 import com.zeligsoft.domain.omg.corba.dsl.idl.MultExpr;
@@ -108,35 +106,14 @@ public class XtendUtils {
 
 	private static Package zdlModel = null;
 	
-	private static Package topLevelPackage = null;
-	
-	// This list tracks the current stack of files we are processing.
-	private static ArrayList<Package> idlFiles = new ArrayList<Package>();
-	
 	// This list tracks the history of all files we have processed.
 	private static ArrayList<Package> visitedFiles = new ArrayList<Package>();
 	
 	private static ArrayList<ScopeFinder> scopeFinders = new ArrayList<ScopeFinder>();
 	
-	/**
-	 * Apply the IDLFile concept to the top-level package being created.
-	 * 
-	 * @param p
-	 */
-	public static void applyIDLFileConcept(Package p)
-	{
-		ZDLUtil.addZDLConcept(p, CXDomainNames.IDLFILE);
-		topLevelPackage = p;
-	} 
-	
-	public static void setTopLevelPackage(Package p) {
-		topLevelPackage = p;
-	}
-	
 	public static void setupZDLModel(Package m) {
 		zdlModel = m;
 		initializeTypeMap(m);
-		idlFiles.clear();
 		visitedFiles.clear();
 		unresolvedLookups.clear(); 
 		scopeFinders.clear();
@@ -161,87 +138,6 @@ public class XtendUtils {
 		String[] chunks = idlFileURI.split("/"); 
 		String filename = chunks[chunks.length - 1];
 		p.setName(filename.replace(".idl", ""));
-	}
-	
-	/**
-	 * Handle #file directives in a preprocessed IDL file.
-	 * 
-	 * @param file
-	 * @param pkg
-	 */
-	public static void handleFileMarker(File_Marker file, Package pkg) {
-		
-		String fileString = file.getFile();
-		String fileName = fileString
-				.substring(fileString.indexOf(":") + 1,
-						fileString.lastIndexOf(":")).replace(".idl", "")
-				.replace("\\", "");
-		
-		if( idlFiles.size() > 1 && fileName.matches(idlFiles.get(idlFiles.size() - 2).getName())) {
-			// This is an end-of-file marker. Pop the stack
-			idlFiles.remove(idlFiles.size() - 1);
-		} else {
-			
-			Package includeTarget = null;
-			
-			for( Package visitedFile : visitedFiles ) {
-				if( fileName.matches(visitedFile.getName())) {
-					includeTarget = visitedFile;
-				}
-			}
-			
-			if( includeTarget == null ) {
-				// create a new IDLFile
-				Package newIDLFile = pkg.createNestedPackage(fileName);
-				ZDLUtil.addZDLConcept(newIDLFile, CXDomainNames.IDLFILE);
-				visitedFiles.add(newIDLFile);
-				idlFiles.add(newIDLFile);
-			} else {
-				// set the currently processed file to the previously visited IDLFile
-				idlFiles.add(includeTarget);
-			}
-			
-			if( idlFiles.size() > 2 ) {
-				// This is an #include. Add the appropriate relationship between the last two IDLFiles processed.
-				Dependency dep = idlFiles.get(idlFiles.size() - 2).createDependency(idlFiles.get(idlFiles.size() - 1));
-				ZDLUtil.addZDLConcept(dep, CXDomainNames.IDLIMPORT);
-			}			
-						
-						
-		}
-	}
-	
-	/**
-	 * Handle #excluded_file directives in a preprocessed IDL file.
-	 * 
-	 * @param file
-	 * @param pkg
-	 */
-	public static void handleFileMarker(Excluded_File_Marker file, Package pkg) {
-		String name = file.getFile().replaceAll("\"", "");
-		name = name.substring(0, name.lastIndexOf(".idl"));	
-	
-		// Attempt to resolve the include with an IDLFile already in the model or one of its package imports.			
-		List<NamedElement> foundPackages = findIDLElement(zdlModel, name, CXDomainNames.IDLFILE);
-		if( foundPackages.size() == 0 ) {
-			// If the IDLFile was not in the model it may be in one of its package imports.
-			for( PackageImport pi : zdlModel.getPackageImports()) {
-				foundPackages = findIDLElement(pi.getImportedPackage(), name, CXDomainNames.IDLFILE);
-				if( foundPackages.size() > 0 ) break;
-			}
-		}
-		if( foundPackages.size() > 0 ) {
-			Dependency dep = idlFiles.get(idlFiles.size() - 1).createDependency(foundPackages.get(0));
-			ZDLUtil.addZDLConcept(dep, CXDomainNames.IDLIMPORT);
-		}
-	}
-	
-	public static Package getCurrentFile() {
-		if( idlFiles.size() == 0 ) {
-			return topLevelPackage;
-		}
-		
-		return idlFiles.get(idlFiles.size() - 1);
 	}
 	
 	/**

--- a/bundles/com.zeligsoft.domain.omg.corba.idlimport/template/idlimport.ext
+++ b/bundles/com.zeligsoft.domain.omg.corba.idlimport/template/idlimport.ext
@@ -1,5 +1,4 @@
 import idl; // needed for IDL DSL
-import CXDomain::IDLFileSupport; // needed for IDLFile and similar
 import CXDomain::IDL; // needed for CXModule etc. 
 import ZMLMM::ZML_Component;
 import ZMLMM::ZML_Core;
@@ -15,30 +14,8 @@ create uml::Package mainTransform(Specification model, ZMLMM::ZML_Core::NamedEle
     resolveUnresolvedLookups() ->
     this.packagedElement.get(0).zdlAsPackage().destroy();
     
-private Void visitContained(File_Marker file, uml::Package package ) :
-	JAVA com.zeligsoft.domain.omg.corba.idlimport.XtendUtils.handleFileMarker(
-		com.zeligsoft.domain.omg.corba.dsl.idl.File_Marker,
-		org.eclipse.uml2.uml.Package);
-		
-private Void visitContained(Excluded_File_Marker file, uml::Package package ) :
-	JAVA com.zeligsoft.domain.omg.corba.idlimport.XtendUtils.handleFileMarker(
-		com.zeligsoft.domain.omg.corba.dsl.idl.Excluded_File_Marker,
-		org.eclipse.uml2.uml.Package);
-
-private void visitContained(Preproc_Pragma pragma, uml::Package package ) :
-	getCurrentFile().setPrefix(pragma.value);
-			
-IDLFile getCurrentFile() :
-	JAVA com.zeligsoft.domain.omg.corba.idlimport.XtendUtils.getCurrentFile();
-        
-Void applyIDLFileConcept(uml::Package pkg) :	
-	JAVA com.zeligsoft.domain.omg.corba.idlimport.XtendUtils.applyIDLFileConcept(org.eclipse.uml2.uml.Package);
-	
 Void setupZDLModel(uml::Package model) :
 	JAVA com.zeligsoft.domain.omg.corba.idlimport.XtendUtils.setupZDLModel(org.eclipse.uml2.uml.Package);
-
-Void setPackageName(uml::Package pkg, String idlFileName) :
-	JAVA com.zeligsoft.domain.omg.corba.idlimport.XtendUtils.setPackageName(org.eclipse.uml2.uml.Package, java.lang.String);
 
 Void resolveUnresolvedLookups() :
 	JAVA com.zeligsoft.domain.omg.corba.idlimport.XtendUtils.resolveUnresolvedLookups();
@@ -69,7 +46,7 @@ Void visitContained(ConstrForwardDecl decl, CXModule container ) : {};
 Void visitContained(ConstrForwardDecl decl,  uml::Package container ) : {};	
 	
 private create CXModule visitContained(Module module, uml::Package container) :
-	getCurrentFile().contents.add(this) ->
+	container.packagedElement.add(this) ->
 	this.configureModule(module);
 
 private create CXModule visitContained(Module module, CXModule container) :
@@ -85,7 +62,7 @@ create CXInterface visitContained(Interface_decl intf, CXModule container) :
 	this.configureInterface(intf);
 	
 private create CXInterface visitContained(Interface_decl intf, uml::Package container) :
-	getCurrentFile().contents.add(this) ->
+	container.packagedElement.add(this) ->
 	this.configureInterface(intf);
 	
 Void configureInterface(CXInterface zInterface, Interface_decl intf) :
@@ -180,7 +157,7 @@ create CXStruct visitContained(StructType struct, CXInterface interface ) :
 	this.configureStruct(struct);
 	
 private create CXStruct visitContained(StructType struct, uml::Package package ) :
-	getCurrentFile().contents.add(this) ->
+	package.packagedElement.add(this) ->
 	this.configureStruct(struct);
 	
 Void configureStruct(CXStruct zStruct, StructType struct) :
@@ -258,7 +235,7 @@ create CXException visitContained(ExceptDecl exception, CXInterface interface ) 
 	this.configureException(exception);
 	
 private create CXException visitContained(ExceptDecl exception, uml::Package package ) :
-	getCurrentFile().contents.add(this) ->
+	package.packagedElement.add(this) ->
 	this.configureException(exception);
 	
 Void configureException(CXException zException, ExceptDecl exception) :
@@ -283,13 +260,6 @@ create CXConstant visitContained(ConstDecl const, CXModule module) :
 	this.setTypedElementType(const.type) ->
 	this.setDefault(values.get(values.size - 1));
 
-private create CXConstant visitContained(ConstDecl const, uml::Package file) :
-	let values = const.value.getConstValue().split("::") :
-	getCurrentFile().addConstant(this) ->
-	this.setName(const.name) ->
-	this.setTypedElementType(const.type) ->
-	this.setDefault(values.get(values.size - 1));
-	
 Void addConstant(uml::Package package, CXConstant const) :
 	JAVA com.zeligsoft.domain.omg.corba.idlimport.XtendUtils.addConstant(
 		org.eclipse.uml2.uml.Package,
@@ -318,8 +288,8 @@ create CXEnum visitContained(EnumType enum, CXModule module ) :
 	module.contents.add(this) ->
 	this.configureEnum(enum);
 	
-private create CXEnum visitContained(EnumType enum, uml::Package file) :
-	getCurrentFile().contents.add(this) ->
+private create CXEnum visitContained(EnumType enum, uml::Package package) :
+	package.packagedElement.add(this) ->
 	this.configureEnum(enum);
 	
 Void configureEnum(CXEnum zEnum, EnumType enum ) :
@@ -343,9 +313,9 @@ create uml::DataType visitContained(TypeDeclarator typedef, CXModule module) :
 	this.setName(typedef.declarators.get(0).id) ->	
 	this.applyTypedefConcept(typedef);	
 
-private create uml::DataType visitContained(TypeDeclarator typedef, uml::Package file) :
+private create uml::DataType visitContained(TypeDeclarator typedef, uml::Package package) :
 	// could be a typedef, a sequence, or an array.
-	getCurrentFile().zdlAsPackage().packagedElement.add(this) ->
+	package.packagedElement.add(this) ->
 	this.setName(typedef.declarators.get(0).id) ->	
 	this.applyTypedefConcept(typedef);	
 	
@@ -370,7 +340,7 @@ create CXUnion visitContained(UnionType union, CXModule module) :
 	this.addCORBAUnionAttributes(union);
 
 create CXUnion visitContained(UnionType union, uml::Package package) :
-	getCurrentFile().contents.add(this) ->
+	package.packagedElement.add(this) ->
 	union.isAppendable?
 	  this.setExtensibility(ExtensibilityKind::Appendable) :
 	  this.setExtensibility(ExtensibilityKind::Final) ->


### PR DESCRIPTION
Fix IDLImport issue with Union.
Correctly put Unions under the destination package.
Remove IDLFile related import code since the model is not shared with the SCA domain.