### PR TITLE
Issue #308: Do not include papyrus patch in RPMs

### DIFF
--- a/papyrus-patch/v4.4.0/site-papyrus-patch/site.xml
+++ b/papyrus-patch/v4.4.0/site-papyrus-patch/site.xml
@@ -4,7 +4,7 @@
 
    <category-def name="com.zeligsoft.cx.papyruspatch" label="Papyrus Patch (required)">
       <description>
-         Provides Groovy support to Eclipse.
+         Provides Papyrus patches for CX4CBDDS.
       </description>
    </category-def>
 

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ The build requires:
 
 ## Building
 
-A github action automatically builds master and papyrus branches as well as all pull requests. 
+A github action automatically builds master and papyrus branches as well as all pull requests.
 
 To build manually;
 
@@ -50,11 +50,11 @@ The following was found to be acceptable:
 	ulimit -Sn 1024
 </pre>
 
-The p2 repositories produced by the build will be found in `releng/com.zeligsoft.dds4ccm.update.atcd/target` 
+The p2 repositories produced by the build will be found in `releng/com.zeligsoft.dds4ccm.update.atcd/target`
 and `releng/com.zeligsoft.dds4ccm.update.axcioma/target`:
 
-* The sub directory `repository` is the created p2 repository. 
-* The files `dds4ccm_axcioma_<version>.zip` and `papyrus_v440_patch_<version>.zip` 
+* The sub directory `repository` is the created p2 repository.
+* The files `dds4ccm_axcioma_<version>.zip` and `papyrus_v440_patch_<version>.zip`
 are zip archives of these repositories.
 * The build also creates a ZIP ending with `SNAPSHOT.zip`. The files are identical.
 The dated ZIP files are useful for distributing regular builds to a file server, allowing you
@@ -62,11 +62,34 @@ to distinguish build between results of successive builds.
 
 ## Installing
 
-DDS4CCM can be installed in Eclipse Papyrus 2019-06 release (4.4.0). 
+DDS4CCM can be installed in Eclipse Papyrus 2019-06 release (4.4.0).
 The release can be downloaded from `https://archive.eclipse.org/modeling/mdt/papyrus/rcp/2019-06/4.4.0/`.
 A default installation should be sufficient. To install:
 
+### Install the Papyrus Patch
+
+Note that this only needs to be done once, even if installing an updated CX.
+
 1. Start Papyrus as a super user. **This is important.**
+2. From the **Help** menu, choose **Install New Software** to start the **Install** wizard.
+3. On the **Available Software** page, click the **Add** button, to add a new software site.
+4. In the **Add Repository** dialog, click the **Archive** button, and in the dialog, browse for
+the `papyrus_v440_patch_<version>.zip` file. Click **OK**.
+5. Click **OK** to close the **Add Repository** dialog.
+6. On returning to the **Install** dialog, check the checkbox beside **Papyrus Patch (required)**.
+7. With the installation features selected, press **Next**.
+8. On the **Install Details** page, you should see additional information on features to
+be installed.
+If error messages are reported, please contact us. Click **Next** to continue.
+9. On the **Review Licenses** page, click the **I accept...** radio button, then click **Finish**.
+10. During the execution of the wizard, your may be prompted to approve the installation
+of unsigned features. This will all have `com.zeligsoft` as a prefix to their names. Approve them.
+11. Once the install has completed, you will be prompted to restart Papyrus. Do this.
+
+### Install CX
+
+1. Start Papyrus as a super user. **This is important.**
+If Papyrus just restarted because you installed the Papyrus patch, then you may continue.
 2. From the **Help** menu, choose **Install New Software** to start the **Install** wizard.
 3. On the **Available Software** page, click the **Add** button, to add a new software site.
 4. In the **Add Repository** dialog, click the **Archive** button, and in the dialog, browse for
@@ -84,9 +107,7 @@ If error messages are reported, please contact us. Click **Next** to continue.
 10. During the execution of the wizard, your may be prompted to approve the installation
 of unsigned features. This will all have `com.zeligsoft` as a prefix to their names. Approve them.
 11. Once the install has completed, you will be prompted to restart Papyrus. Do this.
-12. Repeat steps 3 through 11, but browsing for `papyrus_v440_patch_<version>.zip`. This installs
-a patch to Papyrus 4.4.0 necessary to fix some copy-paste bugs.
-13. Once restarted, you may exit Papyrus (which you started as a super user in step 1).
+12. Once restarted, you may exit Papyrus (which you started as a super user in step 1).
 
 ## Using CX CBDDS (aka DDS4CCM)
 
@@ -94,16 +115,16 @@ To use CX CBDDS:
 1. start Papyrus as a regular user.
 2. Choose a 'workspace' location, if prompted. This will be the disk location where your
 DDS4CCM projects will be stored.
-3. From the **File** menu, click on **New > Papyrus Project**. 
+3. From the **File** menu, click on **New > Papyrus Project**.
 This will open up the **New Papyrus Project** wizard.
-4. In the **Architecture Contexts** section of the **New Papyrus Project** page, 
+4. In the **Architecture Contexts** section of the **New Papyrus Project** page,
 there should be options for selecting **ATCD** or **AXCIOMA** under **Software Engineering** context.
 Selecting one of these options will show up respective viewpoints in the **Architecture Viewpoints** section.
 5. Select an architecture context and click **Next**.
 6. Enter a project name and click **Next** to continue.
 7. In the **Initialization Information** page, enter a root model element name and click **Finish**.
-8. This should create a Papyrus model with appropriate profile and stereotype application. 
-Clicking on the model in the **Model Explorer** view shows the relevant information in the **Properties** tab.     
+8. This should create a Papyrus model with appropriate profile and stereotype application.
+Clicking on the model in the **Model Explorer** view shows the relevant information in the **Properties** tab.
 
 Further tutorial information is not currently stored in this project.
 

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
@@ -3,8 +3,6 @@
 %define _defaultRel  0.%(date "+%y%m%d%H%M")
 %define _rpmdir      %{_projectdir}/rpm_build/
 %define _targetdir   %{_projectdir}/target
-%define _patchtargetdir %{_projectdir}/../../papyrus-patch/v4.4.0/site-papyrus-patch/target
-%define patch_groups "com.zeligsoft.papyruspatch.feature.group"
 %define feature_groups "com.zeligsoft.base_feature.feature.group, \
     com.zeligsoft.cx_feature.feature.group, \
     com.zeligsoft.domain.idl3plus_feature.feature.group, \
@@ -98,7 +96,6 @@ based systems built on AXCIOMA according to the OMG CCM standard.
 %install
 %{__mkdir_p} %{buildroot}/opt/cx-axcioma
 cp %{_targetdir}/dds4ccm_*.v*.zip %{buildroot}/opt/cx-axcioma/
-cp %{_patchtargetdir}/papyrus_v440_patch_*.v*.zip %{buildroot}/opt/cx-axcioma/
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Allocate files
@@ -147,14 +144,6 @@ timestamp=$(echo /opt/cx-axcioma/*.zip | sed -rn 's/.*\.v([0-9]*)\.zip/\1/p')
    -repository \
    jar:file:/opt/cx-axcioma/dds4ccm_axcioma_%{ver}.v${timestamp}.zip\!/ \
    -installIU %{feature_groups}
-# Install Papyrus patch
-/opt/Papyrus/papyrus \
-   -application org.eclipse.equinox.p2.director \
-   -nosplash \
-   -repository \
-   jar:file:/opt/cx-axcioma/papyrus_v440_patch_%{ver}.v${timestamp}.zip\!/ \
-   -installIU %{patch_groups}
-
 
 %postun
 if [ $1 == 0 ] ; then					# this is an uninstallation, not an upgrade


### PR DESCRIPTION
- revert RPM changes. Patch should be installed separately, when Papyrus is installed.
- correct text in patch P2 repo (non-functional change)
- update root readme.md to explain patching process

Note: You can download the built artifacts from the attached build (the `papyrus_v440_patch_*.zip`, and the RPM `cx-axioma-*.rpm`). For convenience, the following command will install the patch into a Papyrus located in `<papyrus-loc>`, and with the patch located in `<patch-loc>` with version `<version>`:

```
sudo <papyrus-loc>/papyrus -application org.eclipse.equinox.p2.director -nosplash \
  -installIU com.zeligsoft.papyruspatch.feature.group \
  -repository jar:file:<patch-loc>/papyrus_v440_patch_2.1.0.<version>.zip\!/  \
  -vmargs -Xmx1024m
```

To uninstall the patch feature, use:

```
sudo <papyrus-loc>papyrus    -application org.eclipse.equinox.p2.director    -nosplash \
  -uninstallIU com.zeligsoft.papyruspatch.feature.group \
  -r https://archive.eclipse.org/modeling/mdt/papyrus/updates/releases/2019-06/ \
  -vmargs -Xmx1024m
```