### PR TITLE
Papyrus target update

### DIFF
--- a/releng/com.zeligsoft.papyruscx.targetdefinition/papyruscx-release.target
+++ b/releng/com.zeligsoft.papyruscx.targetdefinition/papyruscx-release.target
@@ -1,33 +1,45 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
-<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl --><target name="Papyrus CX Target Platform - Release" sequenceNumber="1604962218">
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="Papyrus CX Target Platform - Release" sequenceNumber="1647461248">
   <locations>
-	  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		  <repository location="https://archive.eclipse.org/tools/cdt/releases/9.11/"/>
-		  <unit id="org.eclipse.cdt.sdk.feature.group" version="9.11.1.202006011430"/>
-	  </location>
-	  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		  <repository location="http://download.eclipse.org/releases/2020-06/"/>
-		  <unit id="org.eclipse.platform.feature.group" version="4.16.0.v20200604-0951"/>
-		  <unit id="org.eclipse.egit.feature.group" version="5.8.0.202006091008-r"/>
-		  <unit id="org.eclipse.jgit.feature.group" version="5.8.0.202006091008-r"/>
-		  <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="1.5.3.v20200520-0756"/>
-		  <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="1.13.0.202004160913"/>
-		  <unit id="org.eclipse.xpand.sdk.feature.group" version="2.2.0.v201605260315"/>
-		  <unit id="org.eclipse.xtend.sdk.feature.group" version="2.22.0.v20200602-1533"/>
-	  </location>
-	  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		  <repository location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202005260905/"/>
-		  <unit id="org.eclipse.emf.compare.diagram.gmf.source.feature.group" version="3.3.11.202005260905"/>
-		  <unit id="org.eclipse.emf.compare.egit.source.feature.group" version="3.3.11.202005260905"/>
-		  <unit id="org.eclipse.emf.compare.ide.ui.source.feature.group" version="3.3.11.202005260905"/>
-		  <unit id="org.eclipse.emf.compare.rcp.ui.source.feature.group" version="3.3.11.202005260905"/>
-		  <unit id="org.eclipse.emf.compare.source.feature.group" version="3.3.11.202005260905"/>
-		  <unit id="org.eclipse.emf.compare.uml2.source.feature.group" version="3.3.11.202005260905"/>
-	  </location>
-	  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		  <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
-		  <unit id="com.google.inject" version="3.0.0.v201605172100"/>
-	  </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.platform.feature.group" version="4.16.0.v20200604-0951"/>
+      <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="1.13.0.202004160913"/>
+      <unit id="com.google.guava" version="21.0.0.v20170206-1425"/>
+      <unit id="org.eclipse.xtend.sdk.feature.group" version="2.22.0.v20200602-1533"/>
+      <unit id="org.eclipse.xtend.typesystem.uml2.feature.group" version="2.2.0.v201605260315"/>
+      <unit id="org.eclipse.xtend.typesystem.xsd.feature.group" version="2.2.0.v201605260315"/>
+      <unit id="org.eclipse.xtend.ui.feature.group" version="2.2.0.v201605260315"/>
+      <unit id="org.eclipse.ocl.ui.feature.group" version="2.12.0.v20200608-1555"/>
+      <unit id="org.eclipse.emf.mwe2.lib" version="2.11.3.v20200520-0756"/>
+      <repository id="eclipse-2020-06" location="http://download.eclipse.org/releases/2020-06/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.egit.feature.group" version="5.8.0.202006091008-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="5.8.0.202006091008-r"/>
+      <repository id="egit" location="https://archive.eclipse.org/egit/updates-5.8/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.emf.compare.source.feature.group" version="3.3.11.202005260905"/>
+      <unit id="org.eclipse.emf.compare.diagram.gmf.source.feature.group" version="3.3.11.202005260905"/>
+      <unit id="org.eclipse.emf.compare.uml2.source.feature.group" version="3.3.11.202005260905"/>
+      <unit id="org.eclipse.emf.compare.egit.source.feature.group" version="3.3.11.202005260905"/>
+      <unit id="org.eclipse.emf.compare.ide.ui.source.feature.group" version="3.3.11.202005260905"/>
+      <unit id="org.eclipse.emf.compare.rcp.ui.source.feature.group" version="3.3.11.202005260905"/>
+      <repository id="emfCompare" location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202005260905/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="com.google.inject" version="3.0.0.v201605172100"/>
+      <repository id="orbit" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.papyrus.sdk.feature.feature.group" version="4.8.0.202006100749"/>
+      <repository id="papyrus" location="https://download.eclipse.org/modeling/mdt/papyrus/updates/releases/2020-06/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.cdt.sdk.feature.group" version="9.11.1.202006011430"/>
+      <repository id="cdt" location="https://archive.eclipse.org/tools/cdt/releases/9.11/"/>
+    </location>
   </locations>
 </target>

--- a/releng/com.zeligsoft.papyruscx.targetdefinition/papyruscx-release.tpd
+++ b/releng/com.zeligsoft.papyruscx.targetdefinition/papyruscx-release.tpd
@@ -26,6 +26,8 @@ location "http://download.eclipse.org/releases/2020-06/" eclipse-2020-06 {
 	org.eclipse.xtend.typesystem.xsd.feature.group
 	org.eclipse.xtend.ui.feature.group
 	org.eclipse.ocl.ui.feature.group
+	org.eclipse.emf.mwe2.lib
+	
 }
 
 location "https://archive.eclipse.org/egit/updates-5.8/" egit {


### PR DESCRIPTION
This commit simply adds the Papyrus SDK to the target platform, as well as a missing dependency to org.eclipse.emf.mwe2.lib required by com.zeligsoft.domain.omg.corba.dsl.

Furthermore, it synchronizes the .tpd and .target files.