### PR TITLE
Issue 383: Updated streamsv2.1.x-maintenance versions to 2.1.1

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -4,13 +4,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.zeligsoft.dds4ccm</groupId>
 	<artifactId>com.zeligsoft.dds4ccm.bundles</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.root</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/ddk/pom.xml
+++ b/ddk/pom.xml
@@ -4,13 +4,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.zeligsoft.dds4ccm</groupId>
 	<artifactId>com.zeligsoft.ddk.bundles</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.root</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,13 +4,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.zeligsoft.dds4ccm</groupId>
 	<artifactId>com.zeligsoft.dds4ccm.features</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.root</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 	</parent>
 
 	<modules>

--- a/papyrus-patch/v4.4.0/pom.xml
+++ b/papyrus-patch/v4.4.0/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.root</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.zeligsoft.dds4ccm</groupId>
 	<artifactId>com.zeligsoft.dds4ccm.root</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.configuration</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath>./releng/com.zeligsoft.dds4ccm.configuration</relativePath>
 	</parent>
 

--- a/releng/com.zeligsoft.ddk.update/pom.xml
+++ b/releng/com.zeligsoft.ddk.update/pom.xml
@@ -5,10 +5,10 @@
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.releng</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.zeligsoft.ddk.update</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<build>

--- a/releng/com.zeligsoft.dds4ccm.configuration/pom.xml
+++ b/releng/com.zeligsoft.dds4ccm.configuration/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.zeligsoft.dds4ccm</groupId>
 	<artifactId>com.zeligsoft.dds4ccm.configuration</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/releng/com.zeligsoft.dds4ccm.update.atcd/pom.xml
+++ b/releng/com.zeligsoft.dds4ccm.update.atcd/pom.xml
@@ -5,10 +5,10 @@
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.releng</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.zeligsoft.dds4ccm.update.atcd</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<build>

--- a/releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.atcd/rpm_build/zeligsoftCX_atcd.spec
@@ -1,5 +1,5 @@
 %define ifdef()   	%if %{expand:%%{?%{1}:1}%%{!?%{1}:0}}
-%define ver       	1.6.1
+%define ver       	2.1.1
 %define _defaultRel	0.%(date "+%y%m%d%H%M")
 %define _rpmdir   	%{_projectdir}/rpm_build/
 %define _targetdir 	%{_projectdir}/target

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/pom.xml
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/pom.xml
@@ -5,10 +5,10 @@
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.releng</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>com.zeligsoft.dds4ccm.update.axcioma</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<build>

--- a/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
+++ b/releng/com.zeligsoft.dds4ccm.update.axcioma/rpm_build/zeligsoftCX_axcioma.spec
@@ -1,5 +1,5 @@
 %define ifdef()      %if %{expand:%%{?%{1}:1}%%{!?%{1}:0}}
-%define ver          2.1.0
+%define ver          2.1.1
 %define _defaultRel  0.%(date "+%y%m%d%H%M")
 %define _rpmdir      %{_projectdir}/rpm_build/
 %define _targetdir   %{_projectdir}/target

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -4,13 +4,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.zeligsoft.dds4ccm</groupId>
 	<artifactId>com.zeligsoft.dds4ccm.releng</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>com.zeligsoft.dds4ccm</groupId>
 		<artifactId>com.zeligsoft.dds4ccm.root</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.1-SNAPSHOT</version>
 	</parent>
 
 	<modules>


### PR DESCRIPTION
- updated all versions to 2.1.1, except this for the papyrus 4.4.0 patch, which remains at 2.1.0
- Kept patch at 2.1.0 because it is very unlikely to change

The build now creates the following 2.1.1 artifacts:

```
./releng/com.zeligsoft.ddk.update/target/com.zeligsoft.ddk.update-2.1.1-SNAPSHOT.zip
./releng/com.zeligsoft.ddk.update/target/ddk_2.1.1.v202204071941.zip
./releng/com.zeligsoft.dds4ccm.update.atcd/target/com.zeligsoft.dds4ccm.update.atcd-2.1.1-SNAPSHOT.zip
./releng/com.zeligsoft.dds4ccm.update.atcd/target/dds4ccm_atcd_2.1.1.v202204071941.zip
./releng/com.zeligsoft.dds4ccm.update.axcioma/target/dds4ccm_axcioma_2.1.1.v202204071941.zip
./releng/com.zeligsoft.dds4ccm.update.axcioma/target/com.zeligsoft.dds4ccm.update.axcioma-2.1.1-SNAPSHOT.zip
```

The build continues to create these 2.1.0 artifacts:

```
./papyrus-patch/v4.4.0/feature-com.zeligsoft.papyruspatch/target/com.zeligsoft.papyruspatch-2.1.0-SNAPSHOT.jar
./papyrus-patch/v4.4.0/site-papyrus-patch/target/site/features/com.zeligsoft.papyruspatch_2.1.0.202204071941.jar
./papyrus-patch/v4.4.0/site-papyrus-patch/target/com.zeligsoft.dds4ccm.papyrus-patch-site-v440-2.1.0-SNAPSHOT.zip
./papyrus-patch/v4.4.0/site-papyrus-patch/target/papyrus_v440_patch_2.1.0.v202204071941.zip
```