### PR TITLE
Papyrus Issue #390

### DIFF
--- a/bundles/com.zeligsoft.base/src/com/zeligsoft/base/util/JavaReflectionUtil.java
+++ b/bundles/com.zeligsoft.base/src/com/zeligsoft/base/util/JavaReflectionUtil.java
@@ -1,0 +1,253 @@
+/**
+ * Copyright 2022 Zeligsoft (2009) Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.zeligsoft.base.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class provides some Java reflection utilities to complement those in the Java standard library.
+ * 
+ * @author Ernesto Posse
+ */
+public final class JavaReflectionUtil {
+	
+	/**
+	 * Returns a list of all the super-classes of the given class, without the class itself.
+	 * 
+	 * <p>The list is ordered starting from {@link Object} going down the inheritance chain to the parent class
+	 * of the given {@code klass}.
+	 * 
+	 * @param klass - a {@link Class}
+	 * @return A {@link List} of {@link Class}es.
+	 */
+	public static List<Class<?>> getAllSuperclassesDown(Class<?> klass) {
+		List<Class<?>> superClasses = new ArrayList<>();
+		if (klass != null && klass != Object.class) {
+			Class<?> superClass = klass.getSuperclass();
+			if (superClass != null) {
+				superClasses.addAll(getAllSuperclassesDown(superClass));
+				superClasses.add(superClass);
+			}
+		}
+		return superClasses;
+	}
+	
+	/**
+	 * Returns a list of all the super-classes of the given class, without the class itself.
+	 * 
+	 * <p>The list is ordered starting from the given {@code klass} going up the inheritance chain to {@link Object}.
+	 * 
+	 * @param klass - a {@link Class}
+	 * @return A {@link List} of {@link Class}es.
+	 */
+	public static List<Class<?>> getAllSuperclassesUp(Class<?> klass) {
+		List<Class<?>> superClasses = new ArrayList<>();
+		if (klass != null && klass != Object.class) {
+			Class<?> superClass = klass.getSuperclass();
+			if (superClass != null) {
+				superClasses.add(superClass);
+				superClasses.addAll(getAllSuperclassesUp(superClass));
+			}
+		}
+		return superClasses;
+	}
+	
+	/**
+	 * Returns a set of all the interfaces implemented by the given {@code klass} (which may itself be an interface).
+	 * 
+	 * <p> The set is ordered, starting with the left-most immediate interface implemented, and follows the 
+	 * graph defined by "implements" and "extends" in a depth-first order, so the last elements are interfaces
+	 * that do not extend any other interface. The set also includes all interfaces of all its superclasses.
+	 * 
+	 * @param klass - a {@link Class}
+	 * @return A {@link Set} of {@link Class}es.
+	 */
+	public static Set<Class<?>> getAllInterfaces(Class<?> klass) {
+		Set<Class<?>> allInterfaces = new LinkedHashSet<Class<?>>();
+		if (klass != null) {
+			Class<?> superClass = klass.getSuperclass();
+			if (superClass != null) {
+				allInterfaces.addAll(getAllInterfaces(superClass));
+			}
+			Class<?>[] interfaces = klass.getInterfaces();
+			if (interfaces != null && interfaces.length > 0) {
+				for (Class<?> i : interfaces) {
+					allInterfaces.add(i);
+					allInterfaces.addAll(getAllInterfaces(i));
+				}
+			}
+		}
+		return allInterfaces;
+	}
+
+	/**
+	 * Returns true if {@code classX} is the same class as class named {@code classYCanonicalName} or 
+	 * {@code classX} is a subclass of a class named {@code classYCanonicalName}.
+	 * 
+	 * <p>The test is performed by comparing the canonical names of the classes involved, so it would return
+	 * true even if the classes where loaded by different {@link ClassLoader}s.
+	 * 
+	 * @see #isSubclassOf
+	 * 
+	 * @param classX - a {@link Class}
+	 * @param classYCanonicalName - a {@link String}; the *canonical* name of a class.
+	 * @return A {@code boolean}
+	 */
+	public static boolean isEqualOrSubclassOf(Class<?> classX, String classYCanonicalName) {
+		return classX.getCanonicalName().equals(classYCanonicalName) 
+				|| isSubclassOf(classX, classYCanonicalName);
+	}
+	
+	/**
+	 * Returns true if {@code classX} is the same class as class {@code classY} or 
+	 * {@code classX} is a subclass of class {@code classY}.
+	 * 
+	 * <p>The test is performed by comparing the canonical names of the classes involved, so it would return
+	 * true even if the classes where loaded by different {@link ClassLoader}s.
+	 * 
+	 * @see #isSubclassOf
+	 * 
+	 * @param classX - a {@link Class}
+	 * @param classY - a {@link Class}
+	 * @return A {@code boolean}
+	 */
+	public static boolean isEqualOrSubclassOf(Class<?> classX, Class<?> classY) {
+		return classX.getCanonicalName().equals(classY.getCanonicalName()) 
+				|| isSubclassOf(classX, classY);
+	}
+	
+	/**
+	 * Returns true if {@code classX} is a subclass of class named {@code classYCanonicalName} but not the same class.
+	 * 
+	 * <p>The test is performed by comparing the canonical names of the classes involved, so it would return
+	 * true even if the classes where loaded by different {@link ClassLoader}s.
+	 * 
+	 * @see {@link #isEqualOrSubclassOf}, {@link #isSubclassOf(Class, Class)}
+	 * 
+	 * @param classX - a {@link Class}
+	 * @param classYCanonicalName - a {@link String}; the *canonical* name of a class.
+	 * @return A {@code boolean}
+	 */
+	public static boolean isSubclassOf(Class<?> classX, String classYCanonicalName) {
+		List<Class<?>> allSuperclassesOfX = getAllSuperclassesUp(classX);
+		for (Class<?> superClass : allSuperclassesOfX) {
+			String superClassCanonicalName = superClass.getCanonicalName();
+			if (superClassCanonicalName.equals(classYCanonicalName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns true if {@code classX} is a subclass of class {@code classY} but not the same class.
+	 * 
+	 * <p>The test is performed by comparing the canonical names of the classes involved, so it would return
+	 * true even if the classes where loaded by different {@link ClassLoader}s.
+	 * 
+	 * @see {@link #isEqualOrSubclassOf}, {@link #isSubclassOf(Class, String)}
+	 * 
+	 * @param classX - a {@link Class}
+	 * @param classY - a {@link Class}
+	 * @return A {@code boolean}
+	 */
+	public static boolean isSubclassOf(Class<?> classX, Class<?> classY) {
+		return isSubclassOf(classX, classY.getCanonicalName());
+	}
+
+	/**
+	 * Returns true if {@code classOrInterfaceX} is the same interface as interface named {@code interfaceYcanonicalName} or 
+	 * {@code classOrInterfaceX} implements interface named {@code interfaceYcanonicalName}.
+	 * 
+	 * <p>The test is performed by comparing the canonical names of the classes/interfaces involved, so it would return
+	 * true even if the classes where loaded by different {@link ClassLoader}s.
+	 * 
+	 * @see {@link #implementsInterface}
+	 * 
+	 * @param classOrInterfaceX - a {@link Class}
+	 * @param interfaceYcanonicalName - a {@link String} with the canonical name of an interface
+	 * @return A {@code boolean}
+	 */
+	public static boolean isEqualOrImplementsInterface(Class<?> classOrInterfaceX, String interfaceYCanonicalName) {
+		return classOrInterfaceX.getCanonicalName().equals(interfaceYCanonicalName) 
+				|| implementsInterface(classOrInterfaceX, interfaceYCanonicalName);
+	}
+	
+	/**
+	 * Returns true if {@code classOrInterfaceX} is the same interface as interface {@code interfaceY} or 
+	 * {@code classOrInterfaceX} implements interface {@code interfaceY}.
+	 * 
+	 * <p>The test is performed by comparing the canonical names of the classes/interfaces involved, so it would return
+	 * true even if the classes where loaded by different {@link ClassLoader}s.
+	 * 
+	 * @see {@link #implementsInterface}
+	 * 
+	 * @param classOrInterfaceX - a {@link Class}
+	 * @param interfaceY - a {@link Class} such that interfaceY.isInterface() returns {@code true}
+	 * @return A {@code boolean}
+	 */
+	public static boolean isEqualOrImplementsInterface(Class<?> classOrInterfaceX, Class<?> interfaceY) {
+		return classOrInterfaceX.getCanonicalName().equals(interfaceY.getCanonicalName()) 
+				|| implementsInterface(classOrInterfaceX, interfaceY);
+	}
+	
+	/**
+	 * Returns true if {@code classOrInterfaceX} implements interface named {@code interfaceYCanonicalName} but is not the same.
+	 * 
+	 * <p>The test is performed by comparing the canonical names of the classes/interfaces involved, so it would return
+	 * true even if the classes where loaded by different {@link ClassLoader}s.
+	 * 
+	 * @see {@link #implementsInterface}
+	 * 
+	 * @param classOrInterfaceX - a {@link Class}
+	 * @param interfaceYCanonicalName - a {@link String} with the canonical name of an interface
+	 * @return A {@code boolean}
+	 */
+	public static boolean implementsInterface(Class<?> classOrInterfaceX, String interfaceYCanonicalName) {
+		Set<Class<?>> allInterfacesOfX = getAllInterfaces(classOrInterfaceX);
+		for (Class<?> interfaceOfX : allInterfacesOfX) {
+			String interfaceOfXCanonicalName = interfaceOfX.getCanonicalName();
+			if (interfaceOfXCanonicalName.equals(interfaceYCanonicalName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns true if {@code classOrInterfaceX} implements interface {@code interfaceY} but is not the same.
+	 * 
+	 * <p>The test is performed by comparing the canonical names of the classes/interfaces involved, so it would return
+	 * true even if the classes where loaded by different {@link ClassLoader}s.
+	 * 
+	 * @see {@link #implementsInterface}
+	 * 
+	 * @param classOrInterfaceX - a {@link Class}
+	 * @param classY - a {@link Class} such that interfaceY.isInterface() returns {@code true}
+	 * @return A {@code boolean}
+	 */
+	public static boolean implementsInterface(Class<?> classOrInterfaceX, Class<?> interfaceY) {
+		if (!interfaceY.isInterface()) {
+			return false;
+		}
+		return implementsInterface(classOrInterfaceX, interfaceY.getCanonicalName());
+	}
+
+}

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/.classpath
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/.project
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.zeligsoft.domain.dds4ccm.ui.errorhandlers</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/META-INF/MANIFEST.MF
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-SymbolicName: com.zeligsoft.domain.dds4ccm.ui.errorhandlers;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Activator: com.zeligsoft.domain.dds4ccm.ui.errorhandlers.Activator
+Bundle-Vendor: %providerName
+Require-Bundle: org.eclipse.ui,
+ org.eclipse.core.runtime,
+ com.zeligsoft.base.ui,
+ org.eclipse.ui.ide
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: com.zeligsoft.domain.dds4ccm.ui.errorhandlers
+Bundle-ActivationPolicy: lazy

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/META-INF/MANIFEST.MF
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  com.zeligsoft.base.ui,
- org.eclipse.ui.ide
+ org.eclipse.ui.ide,
+ com.zeligsoft.base;bundle-version="4.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: com.zeligsoft.domain.dds4ccm.ui.errorhandlers
 Bundle-ActivationPolicy: lazy

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/build.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/build.properties
@@ -2,4 +2,9 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               schema/,\
+               plugin.properties
+src.includes = META-INF/,\
+               schema/,\
+               src/

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/build.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.properties
@@ -1,0 +1,2 @@
+pluginName = Papyrus CX for AXCIOMA Custom Error Handlers
+providerName = Zeligsoft/Lumenix

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.properties
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.properties
@@ -1,2 +1,2 @@
 pluginName = Papyrus CX for AXCIOMA Custom Error Handlers
-providerName = Zeligsoft/Lumenix
+providerName = Zeligsoft (2009) Limited

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension-point id="com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions" name="Undesirable Exceptions" schema="schema/com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions.exsd"/>
+   <extension
+         point="org.eclipse.ui.statusHandlers">
+      <statusHandler
+            class="com.zeligsoft.domain.dds4ccm.ui.errorhandlers.statushandlers.FilteringStatusHandler"
+            id="com.zeligsoft.domain.dds4ccm.ui.errorhandlers.filteringStatusHandler">
+      </statusHandler>
+      <statusHandlerProductBinding
+            handlerId="com.zeligsoft.domain.dds4ccm.ui.errorhandlers.filteringStatusHandler"
+            productId="com.zeligsoft.papyrus-cx.axcioma.rcp.product">
+      </statusHandlerProductBinding>
+   </extension>
+   <extension
+         point="com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions">
+      <undesirableException
+            exceptionClass="java.lang.NullPointerException"
+            maximumDepth="3"
+            originClassNamePattern="org.eclipse.papyrus.views.modelexplorer.ModelExplorerView"
+            originMethodNamePattern="deactivate">
+      </undesirableException>
+      <undesirableException
+            exceptionClass="java.lang.NullPointerException"
+            maximumDepth="2"
+            originClassNamePattern="org.eclipse.papyrus.infra.ui.lifecycleevents.SaveAndDirtyService"
+            originMethodNamePattern="removeInputChangedListener">
+      </undesirableException>
+   </extension>
+
+</plugin>

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension-point id="com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions" name="Undesirable Exceptions" schema="schema/com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions.exsd"/>
+   <extension-point id="undesirableExceptions" name="com.zeligsoft.domain.dds4ccm.ui.errorhandlers" schema="schema/undesirableExceptions.exsd"/>
    <extension
          point="org.eclipse.ui.statusHandlers">
       <statusHandler
@@ -26,6 +26,11 @@
             maximumDepth="2"
             originClassNamePattern="org.eclipse.papyrus.infra.ui.lifecycleevents.SaveAndDirtyService"
             originMethodNamePattern="removeInputChangedListener">
+      </undesirableException>
+      <undesirableException
+            exceptionClassName="java.lang.NullPointerException"
+            originClassNamePattern="org.eclipse.papyrus.uml.decoratormodel.helper.DecoratorModelUtils"
+            originMethodNamePattern="isDecoratorModel">
       </undesirableException>
    </extension>
 

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/plugin.xml
@@ -16,13 +16,13 @@
    <extension
          point="com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions">
       <undesirableException
-            exceptionClass="java.lang.NullPointerException"
+            exceptionClassName="java.lang.NullPointerException"
             maximumDepth="3"
             originClassNamePattern="org.eclipse.papyrus.views.modelexplorer.ModelExplorerView"
             originMethodNamePattern="deactivate">
       </undesirableException>
       <undesirableException
-            exceptionClass="java.lang.NullPointerException"
+            exceptionClassName="java.lang.NullPointerException"
             maximumDepth="2"
             originClassNamePattern="org.eclipse.papyrus.infra.ui.lifecycleevents.SaveAndDirtyService"
             originMethodNamePattern="removeInputChangedListener">

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/schema/com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions.exsd
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/schema/com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions.exsd
@@ -6,7 +6,19 @@
          <meta.schema plugin="com.zeligsoft.domain.dds4ccm.ui.errorhandlers" id="undesirableExceptions" name="Undesirable Exceptions"/>
       </appinfo>
       <documentation>
-         [Enter description of this extension point.]
+         This extension point used to register &quot;undesirable exceptions&quot; to be filtered out when they arise so that they are logged but not handled by the standard error handler, which may result in undesirable pop-ups.
+
+The extension point allows to register a sequence of exceptions. The extension must provide four fields:
+
+1) exceptionClassName: the fully-qualified name of a subclass of java.lang.Throwable, 
+2) originClassNamePattern: a regular expression describing the fully-qualified name(s) of class(es) where the exception might originate,
+3) originMethodNamePattern: a regular expression describing the name(s) of class(es) where the exception might originate,
+4) maximumDepth: an Integer, the maximum depth to look for the class name and method name in the stack trace of an exception
+ 
+If no originClassNamePattern is provided, the regular expression `.*` is assumed as default, i.e. matches any class name.
+If no originMethodNamePattern is provided, the regular expression `.*` is assumed as default, i.e. matches any method name.
+If no maximumDepth is provided, the stack trace length is assumed as default.
+
       </documentation>
    </annotation>
 
@@ -49,14 +61,11 @@
 
    <element name="undesirableException">
       <complexType>
-         <attribute name="exceptionClass" type="string">
+         <attribute name="exceptionClassName" type="string">
             <annotation>
                <documentation>
                   
                </documentation>
-               <appinfo>
-                  <meta.attribute kind="java" basedOn="java.lang.Throwable:"/>
-               </appinfo>
             </annotation>
          </attribute>
          <attribute name="originClassNamePattern" type="string">

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/schema/com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions.exsd
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/schema/com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions.exsd
@@ -1,0 +1,123 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="com.zeligsoft.domain.dds4ccm.ui.errorhandlers" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="com.zeligsoft.domain.dds4ccm.ui.errorhandlers" id="undesirableExceptions" name="Undesirable Exceptions"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="undesirableException"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="undesirableException">
+      <complexType>
+         <attribute name="exceptionClass" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="java.lang.Throwable:"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+         <attribute name="originClassNamePattern" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="originMethodNamePattern" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="maximumDepth" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/schema/undesirableExceptions.exsd
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/schema/undesirableExceptions.exsd
@@ -3,10 +3,10 @@
 <schema targetNamespace="com.zeligsoft.domain.dds4ccm.ui.errorhandlers" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appinfo>
-         <meta.schema plugin="com.zeligsoft.domain.dds4ccm.ui.errorhandlers" id="undesirableExceptions" name="Undesirable Exceptions"/>
+         <meta.schema plugin="com.zeligsoft.domain.dds4ccm.ui.errorhandlers" id="undesirableExceptions" name="com.zeligsoft.domain.dds4ccm.ui.errorhandlers"/>
       </appinfo>
       <documentation>
-         This extension point used to register &quot;undesirable exceptions&quot; to be filtered out when they arise so that they are logged but not handled by the standard error handler, which may result in undesirable pop-ups.
+         This extension point used to register &amp;quot;undesirable exceptions&amp;quot; to be filtered out when they arise so that they are logged but not handled by the standard error handler, which may result in undesirable pop-ups.
 
 The extension point allows to register a sequence of exceptions. The extension must provide four fields:
 
@@ -18,7 +18,6 @@ The extension point allows to register a sequence of exceptions. The extension m
 If no originClassNamePattern is provided, the regular expression `.*` is assumed as default, i.e. matches any class name.
 If no originMethodNamePattern is provided, the regular expression `.*` is assumed as default, i.e. matches any method name.
 If no maximumDepth is provided, the stack trace length is assumed as default.
-
       </documentation>
    </annotation>
 
@@ -61,7 +60,7 @@ If no maximumDepth is provided, the stack trace length is assumed as default.
 
    <element name="undesirableException">
       <complexType>
-         <attribute name="exceptionClassName" type="string">
+         <attribute name="exceptionClassName" type="string" use="required">
             <annotation>
                <documentation>
                   

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/src/com/zeligsoft/domain/dds4ccm/ui/errorhandlers/Activator.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/src/com/zeligsoft/domain/dds4ccm/ui/errorhandlers/Activator.java
@@ -1,0 +1,45 @@
+package com.zeligsoft.domain.dds4ccm.ui.errorhandlers;
+
+import com.zeligsoft.base.ui.ZeligsoftAbstractUIPlugin;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle
+ */
+public class Activator extends ZeligsoftAbstractUIPlugin {
+
+	// The plug-in ID
+	public static final String PLUGIN_ID = "com.zeligsoft.domain.dds4ccm.ui.errorhandlers"; //$NON-NLS-1$
+
+	// The shared instance
+	private static Activator plugin;
+	
+	/**
+	 * The constructor
+	 */
+	public Activator() {
+	}
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
+
+}

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/src/com/zeligsoft/domain/dds4ccm/ui/errorhandlers/statushandlers/FilteringStatusHandler.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/src/com/zeligsoft/domain/dds4ccm/ui/errorhandlers/statushandlers/FilteringStatusHandler.java
@@ -1,0 +1,243 @@
+/**
+ * 
+ */
+package com.zeligsoft.domain.dds4ccm.ui.errorhandlers.statushandlers;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.ui.application.IWorkbenchConfigurer;
+import org.eclipse.ui.internal.ide.IDEWorkbenchErrorHandler;
+import org.eclipse.ui.statushandlers.StatusAdapter;
+
+import com.zeligsoft.domain.dds4ccm.ui.errorhandlers.Activator;
+
+/**
+ * @author eposse
+ *
+ */
+public class FilteringStatusHandler extends IDEWorkbenchErrorHandler {
+
+	public class UndesirableException {
+		private Class<Throwable> exceptionClass;
+		private Pattern originClassNamePattern;
+		private Pattern originMethodNamePattern;
+		private Integer maximumDepth;
+
+		public <T extends Throwable> UndesirableException(Class<T> exceptionClass, String originClassNamePattern,
+				String originMethodNamePattern, Integer maximumDepth) {
+			init(exceptionClass, originClassNamePattern, originMethodNamePattern, maximumDepth);
+		}
+
+		public <T extends Throwable> UndesirableException(Class<T> exceptionClass, String originClassNamePattern,
+				String originMethodNamePattern) {
+			init(exceptionClass, originClassNamePattern, originMethodNamePattern, null);
+		}
+
+		public <T extends Throwable> UndesirableException(Class<T> exceptionClass,
+				String originFullyQualifiedMethodNamePattern, Integer maximumDepth) {
+			String originClassNamePattern = "";
+			String originMethodNamePattern = "";
+			if (originFullyQualifiedMethodNamePattern != null) {
+				int lastDotIndex = originFullyQualifiedMethodNamePattern.lastIndexOf(Character.getNumericValue('.'));
+				originClassNamePattern = originFullyQualifiedMethodNamePattern.substring(0, lastDotIndex);
+				originMethodNamePattern = originFullyQualifiedMethodNamePattern.substring(lastDotIndex);
+			}
+			init(exceptionClass, originClassNamePattern, originMethodNamePattern, maximumDepth);
+		}
+
+		public <T extends Throwable> UndesirableException(Class<T> exceptionClass,
+				String originFullyQualifiedMethodNamePattern) {
+			this(exceptionClass, originFullyQualifiedMethodNamePattern, (Integer) null);
+		}
+
+		private <T extends Throwable> void init(Class<T> exceptionClass, String originClassNamePattern,
+				String originMethodNamePattern, Integer maximumDepth) {
+			this.exceptionClass = (Class<Throwable>) exceptionClass;
+			if (originClassNamePattern == null || originClassNamePattern.isBlank()) {
+				originClassNamePattern = ".*";
+			}
+			if (originMethodNamePattern == null || originMethodNamePattern.isBlank()) {
+				originMethodNamePattern = ".*";
+			}
+			this.originClassNamePattern = Pattern.compile(originClassNamePattern);
+			this.originMethodNamePattern = Pattern.compile(originMethodNamePattern);
+			this.maximumDepth = maximumDepth;
+		}
+
+		public Class<Throwable> getExceptionClass() {
+			return exceptionClass;
+		}
+
+		public Pattern getOriginClassNamePattern() {
+			return originClassNamePattern;
+		}
+
+		public Pattern getOriginMethodNamePattern() {
+			return originMethodNamePattern;
+		}
+
+		public Integer getMaximumDepth() {
+			return maximumDepth;
+		}
+	}
+
+	public final String UNDESIRABLE_EXCEPTIONS_EXTENSION_POINT_ID = "undesirableExceptions";
+	public final String ATTR_NAME_EXCEPTION_CLASS = "exceptionClass";
+	public final String ATTR_NAME_ORIGIN_CLASS_NAME_PATTERN = "originClassNamePattern";
+	public final String ATTR_NAME_ORIGIN_METHOD_NAME_PATTERN = "originMethodNamePattern";
+	public final String ATTR_NAME_MAXIMUM_DEPTH = "maximumDepth";
+
+	private List<UndesirableException> undesirableExceptions = null;
+	private Set<Throwable> filteredExceptions = new HashSet<Throwable>();
+
+	public FilteringStatusHandler() {
+		this(null);
+	}
+
+	public FilteringStatusHandler(IWorkbenchConfigurer configurer) {
+		super(configurer);
+	}
+
+	public List<UndesirableException> getUndesirableExceptions() {
+		if (undesirableExceptions == null) {
+			undesirableExceptions = new ArrayList<>();
+			loadExtensionPoint();
+		}
+		return undesirableExceptions;
+	}
+
+	private void loadExtensionPoint() {
+		IExtensionRegistry extensionRegistry = Platform.getExtensionRegistry();
+		final IExtensionPoint extensionPoint = extensionRegistry.getExtensionPoint(Activator.PLUGIN_ID,
+				UNDESIRABLE_EXCEPTIONS_EXTENSION_POINT_ID);
+		IConfigurationElement[] configurationElements = extensionPoint.getConfigurationElements();
+
+		for (IConfigurationElement configurationElement : configurationElements) {
+			addUndesirableException(configurationElement);
+		}
+	}
+
+	private void addUndesirableException(IConfigurationElement configurationElement) {
+		String exceptionClassName = configurationElement.getAttribute(ATTR_NAME_EXCEPTION_CLASS);
+		if (exceptionClassName == null || exceptionClassName.isBlank()) {
+			Activator.getDefault().warning("Ignoring invalid undesirable exception: no exceptionClass provided; id = "
+					+ configurationElement.getHandleId() + "; name = " + configurationElement.getName());
+			return;
+		}
+		Object instance;
+		try {
+			instance = configurationElement.createExecutableExtension(ATTR_NAME_EXCEPTION_CLASS);
+		} catch (CoreException e) {
+			Activator.getDefault().warning(
+					"Ignoring invalid undesirable exception: unable to create executable extension for exceptionClass; id = "
+							+ configurationElement.getHandleId() + "; name = " + configurationElement.getName()
+							+ "; exceptionClass = " + exceptionClassName);
+			return;
+		}
+		Class<?> klass = instance.getClass();
+		Class<? extends Throwable> exceptionClass;
+		try {
+			exceptionClass = klass.asSubclass(Throwable.class);
+		} catch (ClassCastException e) {
+			Activator.getDefault().warning(
+					"Ignoring invalid undesirable exception: class provided is not a subclass of java.lang.Throwable; id = "
+							+ configurationElement.getHandleId() + "; name = " + configurationElement.getName()
+							+ "; exceptionClass = " + exceptionClassName);
+			return;
+		}
+		String originClassNamePattern = configurationElement.getAttribute(ATTR_NAME_ORIGIN_CLASS_NAME_PATTERN);
+		String originMethodNamePattern = configurationElement.getAttribute(ATTR_NAME_ORIGIN_METHOD_NAME_PATTERN);
+		String maximumDepthStr = configurationElement.getAttribute(ATTR_NAME_MAXIMUM_DEPTH);
+		Integer maximumDepth = null;
+		try {
+			maximumDepth = Integer.parseInt(maximumDepthStr);
+		} catch (NumberFormatException e) {
+			Activator.getDefault().warning(
+					"Ignoring invalid maximum depth in undesirable exception: maximumDepth is not an integer; id = "
+							+ configurationElement.getHandleId() + "; name = " + configurationElement.getName()
+							+ "; maximumDepth = " + maximumDepthStr);
+		}
+		UndesirableException undesirableException = new UndesirableException(exceptionClass, originClassNamePattern,
+				originMethodNamePattern, maximumDepth);
+		undesirableExceptions.add(undesirableException);
+	}
+
+	@Override
+	public void handle(StatusAdapter statusAdapter, int style) {
+		IStatus status = statusAdapter.getStatus();
+		Throwable exception = status.getException();
+		// Go through the exception's "caused by" list,
+		// while we have not previously filtered the exception.
+		// We need to cache exceptions as we filter them, because logging them
+		// causes the status handler to be invoked, so this method is reentrant, and if
+		// we don't cache them, we end up in an infinite loop.
+		while (exception != null && !filteredExceptions.contains(exception)) {
+			if (filter(exception)) {
+				filteredExceptions.add(exception);
+				log(status);
+				return;
+			}
+			exception = exception.getCause();
+		}
+		// If the exception was not filtered, delegate to the standard error handler.
+		// We must check again if the exception has been filtered because the loop above
+		// may have ended is the exception had been previously filtered, and so in that case
+		// we should not delegate to the standard error handler.
+		if (!filteredExceptions.contains(exception)) {
+			super.handle(statusAdapter, style);
+		}
+	}
+
+	private void log(IStatus status) {
+		Activator.getDefault().getLog().log(status);
+	}
+
+	private boolean filter(Throwable exception) {
+		// For each undesirable exception...
+		for (UndesirableException undesirableException : getUndesirableExceptions()) {
+			// If the given exception is an instance of the undesirable exception
+			if (undesirableException.getExceptionClass().isInstance(exception)) {
+				// Get the exception's stack trace
+				StackTraceElement[] stackTrace = exception.getStackTrace();
+				if (stackTrace != null) {
+					// Determine the maximum depth to go to in the stack trace.
+					// It is the smallest between the current trace's length, and the
+					// maximum defined for the undesirable exception, if provided,
+					// otherwise, it is the trace's length.
+					int limit = stackTrace.length;
+					Integer maxDepth = undesirableException.getMaximumDepth();
+					if (maxDepth != null) {
+						limit = Integer.min(limit, maxDepth.intValue());
+					}
+					// Go through each stack trace element, up to the limit determined above
+					for (int depth = 0; depth < limit; depth++) {
+						StackTraceElement stackTraceElement = stackTrace[depth];
+						Matcher classNameMatcher = undesirableException.getOriginClassNamePattern()
+								.matcher(stackTraceElement.getClassName());
+						Matcher methodNameMatcher = undesirableException.getOriginMethodNamePattern()
+								.matcher(stackTraceElement.getMethodName());
+						if (classNameMatcher.matches() && methodNameMatcher.matches()) {
+							// If the stack trace element's class name and method name match the
+							// respective patterns from the undesirable exception, then we
+							// must filter-out this exception
+							return true;
+						}
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+}

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/src/com/zeligsoft/domain/dds4ccm/ui/errorhandlers/statushandlers/UndesirableException.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/src/com/zeligsoft/domain/dds4ccm/ui/errorhandlers/statushandlers/UndesirableException.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2022 Zeligsoft (2009) Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.zeligsoft.domain.dds4ccm.ui.errorhandlers.statushandlers;
+
+import java.util.regex.Pattern;
+
+/**
+ * Instances of this class store information about exceptions that should be filtered by the 
+ * {@link FilteringStatusHandler}.
+ * 
+ * @author Ernesto Posse
+ */
+		
+public class UndesirableException {
+	
+	public String exceptionClassName;
+	public Pattern originClassNamePattern;
+	public Pattern originMethodNamePattern;
+	public Integer maximumDepth;
+
+	public UndesirableException(String exceptionClassName, String originClassNamePattern,
+			String originMethodNamePattern, Integer maximumDepth) {
+		init(exceptionClassName, originClassNamePattern, originMethodNamePattern, maximumDepth);
+	}
+
+	public UndesirableException(FilteringStatusHandler filteringStatusHandler, String exceptionClassName, String originClassNamePattern,
+			String originMethodNamePattern) {
+		init(exceptionClassName, originClassNamePattern, originMethodNamePattern, null);
+	}
+
+	public UndesirableException(String exceptionClassName,
+			String originFullyQualifiedMethodNamePattern, Integer maximumDepth) {
+		String originClassNamePattern = "";
+		String originMethodNamePattern = "";
+		if (originFullyQualifiedMethodNamePattern != null) {
+			int lastDotIndex = originFullyQualifiedMethodNamePattern.lastIndexOf(Character.getNumericValue('.'));
+			originClassNamePattern = originFullyQualifiedMethodNamePattern.substring(0, lastDotIndex);
+			originMethodNamePattern = originFullyQualifiedMethodNamePattern.substring(lastDotIndex);
+		}
+		init(exceptionClassName, originClassNamePattern, originMethodNamePattern, maximumDepth);
+	}
+
+	public UndesirableException(String exceptionClassName,
+			String originFullyQualifiedMethodNamePattern) {
+		this(exceptionClassName, originFullyQualifiedMethodNamePattern, (Integer) null);
+	}
+
+	private void init(String exceptionClassName, String originClassNamePattern,
+			String originMethodNamePattern, Integer maximumDepth) {
+		this.exceptionClassName = exceptionClassName;
+		if (originClassNamePattern == null || originClassNamePattern.isBlank()) {
+			originClassNamePattern = ".*";
+		}
+		if (originMethodNamePattern == null || originMethodNamePattern.isBlank()) {
+			originMethodNamePattern = ".*";
+		}
+		this.originClassNamePattern = Pattern.compile(originClassNamePattern);
+		this.originMethodNamePattern = Pattern.compile(originMethodNamePattern);
+		this.maximumDepth = maximumDepth;
+	}
+
+	public String getExceptionClassName() {
+		return this.exceptionClassName;
+	}
+
+	public Pattern getOriginClassNamePattern() {
+		return this.originClassNamePattern;
+	}
+
+	public Pattern getOriginMethodNamePattern() {
+		return this.originMethodNamePattern;
+	}
+
+	public Integer getMaximumDepth() {
+		return this.maximumDepth;
+	}
+	
+}

--- a/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/src/com/zeligsoft/domain/dds4ccm/ui/errorhandlers/statushandlers/UndesirableExceptionRegistry.java
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ui.errorhandlers/src/com/zeligsoft/domain/dds4ccm/ui/errorhandlers/statushandlers/UndesirableExceptionRegistry.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2022 Zeligsoft (2009) Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.zeligsoft.domain.dds4ccm.ui.errorhandlers.statushandlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.Platform;
+
+import com.zeligsoft.domain.dds4ccm.ui.errorhandlers.Activator;
+
+/**
+ * This class stores {@link UndesirableException}s that have been registered through the "undesirableExceptions"
+ * extension point.
+ * 
+ * <p>The extension point is loaded lazily, when the {@link #getUndesirableExceptions()} method is first invoked.
+ * 
+ * @author Ernesto Posse
+ */
+public class UndesirableExceptionRegistry {
+
+	public final String UNDESIRABLE_EXCEPTIONS_EXTENSION_POINT_ID = "undesirableExceptions";
+	public final String ATTR_NAME_EXCEPTION_CLASS_NAME = "exceptionClassName";
+	public final String ATTR_NAME_ORIGIN_CLASS_NAME_PATTERN = "originClassNamePattern";
+	public final String ATTR_NAME_ORIGIN_METHOD_NAME_PATTERN = "originMethodNamePattern";
+	public final String ATTR_NAME_MAXIMUM_DEPTH = "maximumDepth";
+
+	private List<UndesirableException> undesirableExceptions = null;
+
+	/**
+	 * Get the list of all undesirable exceptions registered through the exception point.
+	 * 
+	 * @return A {@link List} of {@link UndesirableException}s.
+	 */
+	public List<UndesirableException> getUndesirableExceptions() {
+		if (undesirableExceptions == null) {
+			undesirableExceptions = new ArrayList<>();
+			loadExtensionPoint();
+		}
+		return undesirableExceptions;
+	}
+
+	private void loadExtensionPoint() {
+		IExtensionRegistry extensionRegistry = Platform.getExtensionRegistry();
+		final IExtensionPoint extensionPoint = extensionRegistry.getExtensionPoint(Activator.PLUGIN_ID,
+				UNDESIRABLE_EXCEPTIONS_EXTENSION_POINT_ID);
+		IConfigurationElement[] configurationElements = extensionPoint.getConfigurationElements();
+
+		for (IConfigurationElement configurationElement : configurationElements) {
+			addUndesirableException(configurationElement);
+		}
+	}
+
+	private void addUndesirableException(IConfigurationElement configurationElement) {
+		String exceptionClassName = configurationElement.getAttribute(ATTR_NAME_EXCEPTION_CLASS_NAME);
+		if (exceptionClassName == null || exceptionClassName.isBlank()) {
+			Activator.getDefault().warning("Ignoring invalid undesirable exception: no exceptionClassName provided; id = "
+					+ configurationElement.getHandleId() + "; name = " + configurationElement.getName());
+			return;
+		}
+		String originClassNamePattern = configurationElement.getAttribute(ATTR_NAME_ORIGIN_CLASS_NAME_PATTERN);
+		String originMethodNamePattern = configurationElement.getAttribute(ATTR_NAME_ORIGIN_METHOD_NAME_PATTERN);
+		String maximumDepthStr = configurationElement.getAttribute(ATTR_NAME_MAXIMUM_DEPTH);
+		Integer maximumDepth = null;
+		try {
+			maximumDepth = Integer.parseInt(maximumDepthStr);
+		} catch (NumberFormatException e) {
+			Activator.getDefault().warning(
+					"Ignoring invalid maximum depth in undesirable exception: maximumDepth is not an integer; id = "
+							+ configurationElement.getHandleId() + "; name = " + configurationElement.getName()
+							+ "; maximumDepth = " + maximumDepthStr);
+		}
+		UndesirableException undesirableException = new UndesirableException(exceptionClassName, originClassNamePattern,
+				originMethodNamePattern, maximumDepth);
+		undesirableExceptions.add(undesirableException);
+	}
+
+
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -45,6 +45,7 @@
 		<module>com.zeligsoft.domain.dds4ccm.tools</module>
 		<module>com.zeligsoft.domain.dds4ccm.ui</module>
 		<module>com.zeligsoft.domain.dds4ccm.ui.axcioma</module>
+		<module>com.zeligsoft.domain.dds4ccm.ui.errorhandler</module>
 		<module>com.zeligsoft.domain.idl3plus</module>
 		<module>com.zeligsoft.domain.idl3plus.api</module>
 		<module>com.zeligsoft.domain.idl3plus.generator</module>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -45,7 +45,7 @@
 		<module>com.zeligsoft.domain.dds4ccm.tools</module>
 		<module>com.zeligsoft.domain.dds4ccm.ui</module>
 		<module>com.zeligsoft.domain.dds4ccm.ui.axcioma</module>
-		<module>com.zeligsoft.domain.dds4ccm.ui.errorhandler</module>
+		<module>com.zeligsoft.domain.dds4ccm.ui.errorhandlers</module>
 		<module>com.zeligsoft.domain.idl3plus</module>
 		<module>com.zeligsoft.domain.idl3plus.api</module>
 		<module>com.zeligsoft.domain.idl3plus.generator</module>

--- a/features/com.zeligsoft.domain.ngc.ccm-feature/feature.xml
+++ b/features/com.zeligsoft.domain.ngc.ccm-feature/feature.xml
@@ -52,15 +52,6 @@
          version="0.0.0"
          unpack="false"/>
 
-<!--
-   <plugin
-         id="com.zeligsoft.domain.ngc.ccm.idltouml"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
--->
-
    <plugin
          id="com.zeligsoft.domain.dds4ccm.amiconnector"
          download-size="0"
@@ -141,5 +132,12 @@
          download-size="0"
          install-size="0"
          version="0.0.0"/>
+
+   <plugin
+         id="com.zeligsoft.domain.dds4ccm.ui.errorhandlers"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/features/com.zeligsoft.domain.ngc.ccm.axcioma-feature/feature.xml
+++ b/features/com.zeligsoft.domain.ngc.ccm.axcioma-feature/feature.xml
@@ -59,15 +59,6 @@
          version="0.0.0"
          unpack="false"/>
 
-<!--
-   <plugin
-         id="com.zeligsoft.domain.ngc.ccm.idltouml"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
--->
-
    <plugin
          id="com.zeligsoft.domain.dds4ccm.amiconnector"
          download-size="0"
@@ -148,5 +139,12 @@
          download-size="0"
          install-size="0"
          version="0.0.0"/>
+
+   <plugin
+         id="com.zeligsoft.domain.dds4ccm.ui.errorhandlers"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/releng/com.zeligsoft.papyrus-cx.axcioma.rcp/plugin_customization.ini
+++ b/releng/com.zeligsoft.papyrus-cx.axcioma.rcp/plugin_customization.ini
@@ -22,13 +22,16 @@ org.eclipse.ui/DOCK_PERSPECTIVE_BAR=topRight
 # show progress on startup
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP=true
 
+# set default error handler
+org.eclipse.ui/ERROR_HANDLER_ID=com.zeligsoft.domain.dds4ccm.ui.filteringStatusHandler
+
 # Set the viewpoint default value
 org.eclipse.papyrus.infra.viewpoints.policy/papyrusViewpointsConfigurationType=extension
 org.eclipse.papyrus.infra.viewpoints.policy/papyrusViewpointsSelectedStakeholder=Architect
 org.eclipse.papyrus.infra.viewpoints.policy/papyrusViewpointsSelectedViewpoint=ModelBuilder
 
 # Set default Papyrus CSS theme (for comparison, bug 495871)
-#org.eclipse.papyrus.infra.gmfdiag.css/currentTheme=com.zeligsoft.papyruscx.axcioma.rcp.css.theme
+#org.eclipse.papyrus.infra.gmfdiag.css/currentTheme=com.zeligsoft.papyrus-cx.axcioma.rcp.css.theme
 
 # Configure collaborative modeling preferences
 org.eclipse.emf.compare.ide.ui/org.eclipse.emf.compare.ide.ui.preference.preMergeOnConflict=true


### PR DESCRIPTION
This pull request introduces a custom error handler to deal with "undesirable exceptions" as described in Issue #390.

It provides a new status handler called a "FilteringStatusHandler", associated with the new Papyrus-CX product, overriding the default handler.

The new filtering status handler contains a list of "undesirable exceptions" (registered via a new extension point described below). Whenever an exception is thrown and the status handler is triggered (its 'handle' method is invoked), it determines if the cause of the exception matches one of the undesirable exceptions, and if this is the case, it simply logs it and returns, inhibiting any handling by the standard error handler, including pop-ups. Otherwise, if it doesn't match any of the undesirable exceptions registered, it delegates to the standard error handler.

The filtering status handler goes through the exception's "caused-by" chain, and for each exception in the chain it tests whether it is an instance of an undesirable exception, and if so, it goes through the elements of its stack trace to see if the stack trace element has a class name and method name that matches the regular expression of the corresponding undesirable exception, up-to the maximum depth registered for that exception.

The new extension point used to register undesirableExceptions is called "com.zeligsoft.domain.dds4ccm.ui.errorhandlers.undesirableExceptions) and allows to register a sequence of exceptions. The extension must provide four fields:

1) exceptionClass: a subclass of java.lang.Throwable, 
2) originClassNamePattern: a regular expression describing the fully-qualified name(s) of class(es) where the exception might originate,
3) originMethodNamePattern: a regular expression describing the name(s) of class(es) where the exception might originate,
4) maximumDepth: an Integer, the maximum depth to look for the class name and method name in the stack trace of an exception
 
If no originClassNamePattern is provided, the regular expression `.*` is assumed as default, i.e. matches any class name.
If no originMethodNamePattern is provided, the regular expression `.*` is assumed as default, i.e. matches any method name.
If no maximumDepth is provided, the stack trace length is assumed as default.
