### PR TITLE
Added RPM build to maven build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 .DS_Store
 *.zip
 *.rpm
+!releng/com.zeligsoft.papyrus-cx.axcioma.rcp.rpm/

--- a/releng/com.zeligsoft.dds4ccm.configuration/pom.xml
+++ b/releng/com.zeligsoft.dds4ccm.configuration/pom.xml
@@ -7,6 +7,7 @@
 
 	<properties>
 		<tycho.version>2.5.0</tycho.version>
+		<tycho-extras.version>2.5.0</tycho-extras.version>
 		<rootdir>${maven.multiModuleProjectDirectory}</rootdir>
 		<project.build.sourceEncoding>ISO-8859-1
 		</project.build.sourceEncoding>

--- a/releng/com.zeligsoft.papyrus-cx.axcioma.rcp.product/rpm_build/papyrus-cx-axcioma.spec
+++ b/releng/com.zeligsoft.papyrus-cx.axcioma.rcp.product/rpm_build/papyrus-cx-axcioma.spec
@@ -39,6 +39,7 @@ Name:          papyrus-cx-axcioma
 Version:       %{version}
 Release:       %{release}
 Summary:       An Eclipse Papyrus extension for modeling with AXCIOMA
+Group:         Development Tools
 License:       Apache License, Version 2.0
 BuildArch:     x86_64
 URL:           https://github.com/ZeligsoftDev/CX4CBDDS

--- a/releng/com.zeligsoft.papyrus-cx.axcioma.rcp.rpm/.project
+++ b/releng/com.zeligsoft.papyrus-cx.axcioma.rcp.rpm/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.zeligsoft.papyrus-cx.axcioma.rcp.rpm</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/com.zeligsoft.papyrus-cx.axcioma.rcp.rpm/pom.xml
+++ b/releng/com.zeligsoft.papyrus-cx.axcioma.rcp.rpm/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>com.zeligsoft.papyrus-cx.axcioma.rcp.rpm</artifactId>
+	<parent>
+		<groupId>com.zeligsoft.dds4ccm</groupId>
+		<artifactId>com.zeligsoft.dds4ccm.releng</artifactId>
+		<version>2.2.0-SNAPSHOT</version>
+	</parent>
+	<packaging>rpm</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-packaging-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<executions>
+					<execution>
+						<id>build-qualifier</id>
+						<goals>
+							<goal>build-qualifier</goal>
+						</goals>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>tycho-buildtimestamp-jgit</artifactId>
+						<version>${tycho-extras.version}</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<timestampProvider>jgit</timestampProvider>
+					<jgit.ignore>
+						pom.xml
+						.polyglot.build.properties
+					</jgit.ignore>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>rpm-maven-plugin</artifactId>
+				<version>2.2.0</version>
+				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>generate-rpm</id>
+						<goals>
+							<goal>rpm</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<name>papyrus-cx-axcioma</name>
+					<projversion>${unqualifiedVersion}</projversion>
+					<release>${buildQualifier}</release>
+					<license>Apache 2.0 (c) 2022 Zeligsoft (2009) Limited and others</license>
+					<group>Development Tools</group>
+					<icon>../com.zeligsoft.papyrus-cx.axcioma.rcp/icons/papyrus-cx.xpm</icon>
+					<needarch>true</needarch>
+					<repackJars>false</repackJars>
+					<autoProvides>false</autoProvides>
+					<autoRequires>false</autoRequires>
+					<summary>An Eclipse Papyrus extension for modeling with AXCIOMA</summary>
+					<description>Papyrus CX for AXCIOMA is a modelling environment
+						based on Eclipse Papyrus
+						for modeling component-based systems built on AXCIOMA according to
+						the OMG CCM standard.
+					</description>
+					<url>https://github.com/ZeligsoftDev/CX4CBDDS</url>
+					<packager>Zeligsoft (2009) Limited</packager>
+					<vendor>Zeligsoft (2009) Limited</vendor>
+					<verifyScriplet>true</verifyScriplet>
+					<requires>
+						<require>java-11-openjdk</require>
+					</requires>
+					<defineStatements>
+						<defineStatement>_build_id_links none</defineStatement>
+						<defineStatement>_invalid_encoding_terminates_build 0</defineStatement>
+					</defineStatements>
+					<mappings>
+						<mapping>
+							<directory>/opt/papyrus-cx-axcioma/</directory>
+							<sources>
+								<source>
+									<location>../com.zeligsoft.papyrus-cx.axcioma.rcp.product/target/products/com.zeligsoft.papyrus-cx.axcioma.rcp.product/linux/gtk/x86_64/papyrus-cx-axcioma</location>
+								</source>
+							</sources>
+						</mapping>
+						<mapping>
+							<directory>/usr/share/applications/</directory>
+							<sources>
+								<source>
+									<location>resources/papyrus-cx-axcioma.desktop</location>
+								</source>
+							</sources>
+						</mapping>
+					</mappings>
+					<preinstallScriptlet>
+						<script>
+							echo "Installing ${project.name} now"
+						</script>
+					</preinstallScriptlet>
+					<prepareScriplet>
+						<script>echo "Preparing ${project.name} now"</script>
+					</prepareScriplet>
+					<preremoveScriplet>
+						<script>echo "Pre-remove ${project.name} now"</script>
+					</preremoveScriplet>
+					<pretransScriplet>
+						<script>echo "Pre-trans ${project.name} now"</script>
+					</pretransScriplet>
+					<postinstallScriptlet>
+						<script>echo "Installed ${project.name}"</script>
+					</postinstallScriptlet>
+					<postremoveScriplet>
+						<script>echo "Post-remove ${project.name}"</script>
+					</postremoveScriplet>
+					<posttransScriplet>
+						<script>echo "Post-trans ${project.name}"</script>
+					</posttransScriplet>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/releng/com.zeligsoft.papyrus-cx.axcioma.rcp.rpm/resources/papyrus-cx-axcioma.desktop
+++ b/releng/com.zeligsoft.papyrus-cx.axcioma.rcp.rpm/resources/papyrus-cx-axcioma.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Papyrus CX for AXCIOMA
+Comment=Papyrus CX for AXCIOMA
+Exec=/opt/papyrus-cx-axcioma/papyrus-cx
+Icon=/opt/papyrus-cx-axcioma/icon.xpm
+Categories=Application;Development;Java;IDE
+Version=1.0
+Type=Application
+Terminal=false
+StartupNotify=true
+

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -20,5 +20,6 @@
 		<module>com.zeligsoft.papyrus-cx.axcioma.rcp</module>
 		<module>com.zeligsoft.papyrus-cx.axcioma.rcp.feature</module>
 		<module>com.zeligsoft.papyrus-cx.axcioma.rcp.product</module>
+		<module>com.zeligsoft.papyrus-cx.axcioma.rcp.rpm</module>
 	</modules>
 </project>


### PR DESCRIPTION
Introduced building of product RPM by maven.

Uses the [Tycho JGit Build Timestamp Provider Plugin](https://www.eclipse.org/tycho/sitedocs/tycho-extras/tycho-buildtimestamp-jgit/index.html) to ensure that:

* Only produce new artifact version when there are changes.
* Generate the same version qualifier when building from the same git commit.
* Guarantee consistent artifact id, version and contents.

Signed-off-by: Ernesto Posse <ernesto.posse@lumenix.com>