### PR TITLE
Issue #397: Introduced filteredProperty attributes to the model_library_configuration extension point

### DIFF
--- a/bundles/com.zeligsoft.domain.dds4ccm.ddsdcpsconnector/plugin.xml
+++ b/bundles/com.zeligsoft.domain.dds4ccm.ddsdcpsconnector/plugin.xml
@@ -46,6 +46,16 @@
             portIcon="icons/obj16/consumer-port.gif"
             conjugatedPortIcon="icons/obj16/publisher-port.gif">
       </portIcon>
+      <portFilteredProperties
+            portTypeName="DDS_DCPS::CCM_DDS::Typed::DDS_Write">
+         <filteredProperty
+               propertyName="pull_consumer">
+         </filteredProperty>
+         <filteredProperty
+               propertyName="push_consumer">
+         </filteredProperty>
+      </portFilteredProperties>
+
    		</connector>
    		<module name="DDS_DCPS::CCM_DDS">
    			<generationOptions>

--- a/bundles/com.zeligsoft.domain.idl3plus/META-INF/MANIFEST.MF
+++ b/bundles/com.zeligsoft.domain.idl3plus/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.113.0",
  org.eclipse.emf.validation;bundle-version="1.8.0",
  com.zeligsoft.base.validation;bundle-version="4.0.0",
  com.zeligsoft.base.zdl;bundle-version="4.0.0",
- com.zeligsoft.domain.omg.ccm;bundle-version="4.0.0";visibility:=reexport
+ com.zeligsoft.domain.omg.ccm;bundle-version="4.0.0";visibility:=reexport,
+ org.eclipse.gmf.runtime.emf.core
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/bundles/com.zeligsoft.domain.idl3plus/schema/ddsmodellibrary.exsd
+++ b/bundles/com.zeligsoft.domain.idl3plus/schema/ddsmodellibrary.exsd
@@ -61,6 +61,7 @@
             <element ref="generationOptions"/>
             <element ref="importOptions"/>
             <element ref="portIcon" minOccurs="0" maxOccurs="unbounded"/>
+            <element ref="portFilteredProperties" minOccurs="0" maxOccurs="unbounded"/>
          </sequence>
          <attribute name="name" type="string">
             <annotation>
@@ -139,14 +140,37 @@
       </complexType>
    </element>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
+   <element name="portFilteredProperties">
+      <annotation>
+         <documentation>
+            Properties to filter for a given port type.
+         </documentation>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="filteredProperty" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
+         <attribute name="portTypeName" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The fully qualified name of the port type for which properties will be filtered.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="filteredProperty">
+      <complexType>
+         <attribute name="propertyName" type="string" use="required">
+            <annotation>
+               <documentation>
+                  A regular expression determining properties to filter for ports of this type.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
 
    <annotation>
       <appInfo>
@@ -157,6 +181,15 @@
       </documentation>
    </annotation>
 
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiInfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
 
    <annotation>
       <appInfo>

--- a/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/src/com/zeligsoft/domain/ngc/ccm/descriptorgeneration/utils/FilterUtil.java
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/src/com/zeligsoft/domain/ngc/ccm/descriptorgeneration/utils/FilterUtil.java
@@ -1,0 +1,14 @@
+package com.zeligsoft.domain.ngc.ccm.descriptorgeneration.utils;
+
+import org.eclipse.uml2.uml.Property;
+
+import com.zeligsoft.domain.idl3plus.utils.IDL3PlusUtil;
+
+
+public class FilterUtil {
+
+	public static boolean filterPort(Property perPort, Property port) {
+		return IDL3PlusUtil.filter(perPort, port);
+	}
+
+}

--- a/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAxcioma.ext
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.descriptorgeneration/template/mainTransformAxcioma.ext
@@ -36,6 +36,7 @@ extension com::zeligsoft::base::zdl::util::ZDLUtil;
 extension com::zeligsoft::domain::dds4ccm::utils::codeGenUtils;
 extension org::eclipse::xtend::util::stdlib::globalvar;
 extension org::eclipse::xtend::util::stdlib::io;
+extension codegen::debug;
 
 Void enableTrace(String topic) : JAVA
 	com.zeligsoft.domain.ngc.ccm.descriptorgeneration.XDebugUtil.enableTrace(java.lang.String);
@@ -249,6 +250,7 @@ DeploymentPart getHomePart(CCM::CCM_Deployment::DeploymentPlan zDeployment, Home
 	
 Void visitConfigProperty(CXAttribute attribute, InstanceDeploymentDescription idd, DeploymentPart part ) :
 	let defaultSlots = createList(new java::lang::Object) :
+	attribute.Debug("      visitConfigProperty_1(CXAttribute attribute = " + attribute.name + ", ..., DeploymentPart part = " + part.name + ")") ->
 	defaultSlots.addAll(findDefaultSlot(attribute, part)) ->
 	if part.zdlAsProperty().defaultValue != null then
 	{
@@ -274,6 +276,7 @@ Void visitConfigProperty(CXAttribute attribute, InstanceDeploymentDescription id
 	
 Void visitConfigProperty(CCM::CCM_Target::Property property, InstanceDeploymentDescription idd, DeploymentPart part ) :
 	let defaultSlots = createList(new java::lang::Object) :
+	property.Debug("      visitConfigProperty_2(CCM::CCM_Target::Property property = " + property.name + ", ..., DeploymentPart part = " + part.name + ")") ->
 	// check for and prevent double add of a property.
 	if(!idd.configProperty.name.exists(n | n == property.name)) then {
 		defaultSlots.addAll(findDefaultSlot(property, part)) ->
@@ -435,6 +438,7 @@ DeploymentPart getPerPortDP(DeploymentPart part , DataSpace dataSpace, CCM::CCM_
  */
 Void visitDataSpaceProperty(CXAttribute attribute, InstanceDeploymentDescription idd, DeploymentPart perPort, DeploymentPart dataSpace) :
 	let defaultSlots = createList(new java::lang::Object) :
+	attribute.Debug("visitDataSpaceProperty_1(CXAttribute attribute = " + attribute.name + ", ..., DeploymentPart perPort = " + perPort.name + ", DeploymentPart dataSpace = " + dataSpace.name + ")") ->
 	defaultSlots.addAll(findDefaultSlot(attribute, dataSpace)) ->
 	if (perPort != null && perPort.zdlAsProperty().defaultValue != null && perPort.zdlAsProperty().defaultValue.zdlAsInstanceValue().instance.zdlAsInstanceSpecification().slot.selectFirst( slot | slot.definingFeature == attribute) != null) then
 	{
@@ -464,13 +468,19 @@ Void visitDataSpaceProperty(CXAttribute attribute, InstanceDeploymentDescription
 	};
 	
 Void visitDataSpaceProperty(InterfacePort port, InstanceDeploymentDescription idd, DeploymentPart perPort, DeploymentPart dataSpace) :
-	port.porttype.ownedAttribute.visitDataSpaceProperty(port, idd, perPort, dataSpace);
+	port.Debug("visitDataSpaceProperty_2(InterfacePort port = " + port.name + ", ..., DeploymentPart perPort = " + perPort.name + ", DeploymentPart dataSpace = " + dataSpace.name + ")") ->
+	if (!filterPort(perPort, port)) then 
+	{
+		port.porttype.ownedAttribute.visitDataSpaceProperty(port, idd, perPort, dataSpace)
+	};
 	
 Void visitDataSpaceProperty(CXAttribute attribute, InterfacePort port, InstanceDeploymentDescription idd, DeploymentPart perPort, DeploymentPart dataSpace ) :
+	port.Debug("visitDataSpaceProperty_3(CXAttribute attribute = " + attribute.name + ", InterfacePort port = " + port.name + ", ..., DeploymentPart perPort = " + perPort.name + ", DeploymentPart dataSpace = " + dataSpace.name + ")") ->
 	if(perPort != null && perPort.zdlAsProperty().defaultValue != null && perPort.zdlAsProperty().defaultValue.zdlAsInstanceValue().instance.zdlAsInstanceSpecification().slot.selectFirst( slot | slot.definingFeature == port) != null) then
 	{
 		let defaultSlots = createList(new java::lang::Object) :
 		let slot2 = perPort.zdlAsProperty().defaultValue.zdlAsInstanceValue().instance.zdlAsInstanceSpecification().slot.selectFirst( slot | slot.definingFeature == port).value.first().zdlAsInstanceValue().instance.zdlAsInstanceSpecification().slot.selectFirst( slot | slot.definingFeature == attribute) :
+		port.Debug("  case 1") ->
 		defaultSlots.addAll(findDefaultSlot(attribute, port, dataSpace)) ->
 		slot2.visitConfigProperty(idd, defaultSlots).addPortPrefix(port)
 	}
@@ -479,11 +489,14 @@ Void visitDataSpaceProperty(CXAttribute attribute, InterfacePort port, InstanceD
 		let slot = dataSpace.zdlAsProperty().defaultValue.zdlAsInstanceValue().instance.zdlAsInstanceSpecification().slot.selectFirst
 			( slot | slot.definingFeature == port) :
 		let defaultSlots = createList(new java::lang::Object) :
+		port.Debug("  case 2") ->
 		defaultSlots.addAll(findDefaultSlot(attribute, port, dataSpace)) ->
 		if( slot == null ) then 
 		{
+			port.Debug("    case 2.1 slot == null") ->
 			if( !defaultSlots.isEmpty ) then {
 				let defaultSlot = defaultSlots.get(0) :
+				port.Debug("      case 2.1.1 !defaultSlots.isEmpty") ->
 				defaultSlots.remove(defaultSlot) ->
 				defaultSlot.visitConfigProperty(idd, defaultSlots).addPortPrefix(port)
 			}	
@@ -491,15 +504,19 @@ Void visitDataSpaceProperty(CXAttribute attribute, InterfacePort port, InstanceD
 		else 
 		{
 			let slot2 = slot.value.first().zdlAsInstanceValue().instance.zdlAsInstanceSpecification().slot.selectFirst( slot | slot.definingFeature == attribute) :
+			port.Debug("    case 2.2 slot != null") ->
 			slot2.visitConfigProperty(idd, defaultSlots).addPortPrefix(port)
 		} 
 	} 
 	else
 	{
 		let defaultSlots = createList(new java::lang::Object) :
+		port.Debug("  case 3") ->
 		defaultSlots.addAll(findDefaultSlot(attribute, dataSpace)) ->
 		if( !defaultSlots.isEmpty ) then {
 				let defaultSlot = defaultSlots.get(0) :
+				port.Debug("    case 3.1 !defaultSlots.isEmpty") ->
+				port.Debug("      defaultSlots = " + defaultSlots) ->
 				defaultSlots.remove(defaultSlot) ->
 				defaultSlot.visitConfigProperty(idd, defaultSlots).addPortPrefix(port)
 		}
@@ -1480,3 +1497,7 @@ String getModelTypeSpecificProperty(String property):
 String getModelTypeSpecificProperty(String modelType, String property):
 	JAVA com.zeligsoft.domain.dds4ccm.utils.DDS4CCMUtil.getPropertyName(
 		java.lang.String, java.lang.String);
+
+Boolean filterPort(DeploymentPart perPort, InterfacePort port) : JAVA
+	com.zeligsoft.domain.ngc.ccm.descriptorgeneration.utils.FilterUtil.filterPort(org.eclipse.uml2.uml.Property, org.eclipse.uml2.uml.Property);
+

--- a/bundles/com.zeligsoft.domain.omg.ccm.descriptorgenerator/src/com/zeligsoft/domain/omg/ccm/descriptorgenerator/utils/cdpgenerator.ext
+++ b/bundles/com.zeligsoft.domain.omg.ccm.descriptorgenerator/src/com/zeligsoft/domain/omg/ccm/descriptorgenerator/utils/cdpgenerator.ext
@@ -28,6 +28,7 @@ import CXDomain::IDL;
 extension org::eclipse::xtend::util::stdlib::issues;
 extension com::zeligsoft::domain::omg::ccm::descriptorgenerator::utils::util;
 extension com::zeligsoft::domain::omg::corba::util::corbautil;
+extension codegen::debug;
 
 
 String getFileName(DeploymentPlan deployment) :
@@ -55,14 +56,17 @@ cached String getOverridePropertyValue(DeploymentPart part, String propertyName 
 		getPropertySlotValue(part.zdlAsProperty().defaultValue.zdlAsInstanceValue(), propertyName);
 
 Void visitConfigProperty(uml::InstanceValue value, InstanceDeploymentDescription inst) :
+	value.Debug("      visitConfigProperty_3(uml::InstanceValue value = " + value + ", ...)") ->
 	value.instance.zdlAsInstanceSpecification().slot.visitConfigProperty(inst);
 	
 Property visitConfigProperty(uml::Slot slot, InstanceDeploymentDescription inst, List[uml::Slot] defaultSlots) :
 	let attribute = slot.definingFeature :
 	let value = slot.value.first() :
+	value.Debug("      visitConfigProperty_4(uml::Slot slot = " + slot + ", ...)") ->
 	visitConfigProperty(attribute, value.zdlAsInstanceValue(), inst, defaultSlots);
 	
 create Property visitConfigProperty(CCM::CCM_Target::Property property, uml::InstanceValue value, InstanceDeploymentDescription inst, List[uml::Slot] defaultSlots ) :
+	value.Debug("      visitConfigProperty_5(CCM::CCM_Target::Property property = " + property.name + ", ...)") ->
 	this.name.add(property.name) ->
 	this.value.add(visitPropertyValue(property, value, inst, defaultSlots)) ->
 	inst.configProperty.add(this);
@@ -83,6 +87,7 @@ create DataType visitAttributeType(CCM::CCM_Target::Property property, Any obj) 
 	corbaType.visitBoundedStringType(this);
 	
 create Property visitConfigProperty(CXAttribute attr, uml::InstanceValue value, InstanceDeploymentDescription inst, List[uml::Slot] defaultSlots ) :
+	value.Debug("      visitConfigProperty_6(CXAttribute attr = " + attr.name + ", ...)") ->
 	this.name.add(attr.name) ->
 	this.value.add(visitPropertyValue(attr, value, inst, defaultSlots)) ->
 	inst.configProperty.add(this);


### PR DESCRIPTION
This commit uses the extension point to filter properties in the Properties section
of a connector and to filter properties in the descriptor generator.

Signed-off-by: Ernesto Posse <ernesto.posse@lumenix.com>
