### PR TITLE
Issue #493: change IDL generation replacing //@top-level with @nested

### DIFF
--- a/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/writers/AtcdWriterSwitch.java
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/writers/AtcdWriterSwitch.java
@@ -284,13 +284,13 @@ public class AtcdWriterSwitch extends IDL3PlusWriterSwitch {
 		@Override
 		public Object caseStructType(StructType object) {
 			
-			String commentString = "//@top-level false";
+			boolean nested = true;
 			
 			EAnnotation annotation = object.getEAnnotation(AnnotationUtil.ZCX_ANNOTATION);
 			if( annotation != null ) {
 				String topLevel = annotation.getDetails().get("toplevel");
 				if( topLevel != null && topLevel.matches("true")) {
-					commentString = "//@top-level true";
+					nested = false;
 				}
 			}
 			
@@ -307,6 +307,12 @@ public class AtcdWriterSwitch extends IDL3PlusWriterSwitch {
 				}
 			}
 			
+			String nestedAnnotation = "@nested(FALSE)";
+			if (nested) {
+				nestedAnnotation = "@nested(TRUE)";
+			}
+			buf.append(String.format("%s%s%n", indentString, nestedAnnotation));
+
 			buf.append(String.format("%sstruct %s {%n", 
 					indentString,
 					object.getName()));
@@ -315,8 +321,8 @@ public class AtcdWriterSwitch extends IDL3PlusWriterSwitch {
 				doSwitch(m);					
 			}
 			popScope();
-			buf.append(String.format("%s}; %s%n",
-					indentString, commentString));
+			buf.append(String.format("%s};%n",
+					indentString));
 			conditionalNewLine();
 			return buf.toString();
 		}

--- a/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/writers/AtcdWriterSwitch.java
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/writers/AtcdWriterSwitch.java
@@ -284,13 +284,13 @@ public class AtcdWriterSwitch extends IDL3PlusWriterSwitch {
 		@Override
 		public Object caseStructType(StructType object) {
 			
-			boolean nested = true;
+			String commentString = "//@top-level false";
 			
 			EAnnotation annotation = object.getEAnnotation(AnnotationUtil.ZCX_ANNOTATION);
 			if( annotation != null ) {
 				String topLevel = annotation.getDetails().get("toplevel");
 				if( topLevel != null && topLevel.matches("true")) {
-					nested = false;
+					commentString = "//@top-level true";
 				}
 			}
 			
@@ -307,12 +307,6 @@ public class AtcdWriterSwitch extends IDL3PlusWriterSwitch {
 				}
 			}
 			
-			String nestedAnnotation = "@nested(FALSE)";
-			if (nested) {
-				nestedAnnotation = "@nested(TRUE)";
-			}
-			buf.append(String.format("%s%s%n", indentString, nestedAnnotation));
-
 			buf.append(String.format("%sstruct %s {%n", 
 					indentString,
 					object.getName()));
@@ -321,8 +315,8 @@ public class AtcdWriterSwitch extends IDL3PlusWriterSwitch {
 				doSwitch(m);					
 			}
 			popScope();
-			buf.append(String.format("%s};%n",
-					indentString));
+			buf.append(String.format("%s}; %s%n",
+					indentString, commentString));
 			conditionalNewLine();
 			return buf.toString();
 		}

--- a/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/writers/AxciomaWriterSwitch.java
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/writers/AxciomaWriterSwitch.java
@@ -338,13 +338,13 @@ public class AxciomaWriterSwitch extends IDL3PlusWriterSwitch {
 		@Override
 		public Object caseStructType(StructType object) {
 			
-			String commentString = "//@top-level false";
+			boolean nested = false;
 			
 			EAnnotation annotation = object.getEAnnotation(AnnotationUtil.ZCX_ANNOTATION);
-			if( annotation != null ) {
+			if (annotation != null) {
 				String topLevel = annotation.getDetails().get("toplevel");
-				if( topLevel != null && topLevel.matches("true")) {
-					commentString = "//@top-level true";
+				if (topLevel != null && topLevel.matches("true")) {
+					nested = true;
 				}
 			}
 			
@@ -363,10 +363,15 @@ public class AxciomaWriterSwitch extends IDL3PlusWriterSwitch {
 			
 			// if AXCIOMA
 			String extensibility = "@final";
-			if(object.isIsAppendable()) {
+			if (object.isIsAppendable()) {
 				extensibility = "@appendable";
 			}
 			buf.append(String.format("%s%s%n", indentString, extensibility));
+			String nestedAnnotation = "@nested(FALSE)";
+			if (!nested) {
+				nestedAnnotation = "@nested(TRUE)";
+			}
+			buf.append(String.format("%s%s%n", indentString, nestedAnnotation));
 			
 			buf.append(String.format("%sstruct %s {%n", 
 					indentString,
@@ -376,8 +381,8 @@ public class AxciomaWriterSwitch extends IDL3PlusWriterSwitch {
 				doSwitch(m);					
 			}
 			popScope();
-			buf.append(String.format("%s}; %s%n",
-					indentString, commentString));
+			buf.append(String.format("%s}; %n",
+					indentString));
 			conditionalNewLine();
 			return buf.toString();
 		}

--- a/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/writers/AxciomaWriterSwitch.java
+++ b/bundles/com.zeligsoft.domain.ngc.ccm.generator/src/com/zeligsoft/domain/ngc/ccm/generator/writers/AxciomaWriterSwitch.java
@@ -338,13 +338,13 @@ public class AxciomaWriterSwitch extends IDL3PlusWriterSwitch {
 		@Override
 		public Object caseStructType(StructType object) {
 			
-			boolean nested = false;
+			boolean nested = true;
 			
 			EAnnotation annotation = object.getEAnnotation(AnnotationUtil.ZCX_ANNOTATION);
 			if (annotation != null) {
 				String topLevel = annotation.getDetails().get("toplevel");
 				if (topLevel != null && topLevel.matches("true")) {
-					nested = true;
+					nested = false;
 				}
 			}
 			
@@ -368,7 +368,7 @@ public class AxciomaWriterSwitch extends IDL3PlusWriterSwitch {
 			}
 			buf.append(String.format("%s%s%n", indentString, extensibility));
 			String nestedAnnotation = "@nested(FALSE)";
-			if (!nested) {
+			if (nested) {
 				nestedAnnotation = "@nested(TRUE)";
 			}
 			buf.append(String.format("%s%s%n", indentString, nestedAnnotation));


### PR DESCRIPTION
Updated IDL codegen to use `@nested` annotations instead of `//@top-level` comments on `CXStruct`s and `DDSMessage`s.